### PR TITLE
FIX: el50xx / el5042 I/O interrupt support

### DIFF
--- a/clang-format.sh
+++ b/clang-format.sh
@@ -1,3 +1,5 @@
 #!/bin/bash 
 
-clang-format-14 -i $(find . -iname "*.cpp" -o -iname "*.h")
+CLANG_FMT=$(which clang-format-14 || echo "clang-format")
+
+$CLANG_FMT -i $(find . -iname "*.cpp" -o -iname "*.h")

--- a/ek9000App/src/Makefile
+++ b/ek9000App/src/Makefile
@@ -14,7 +14,9 @@ DBD += ek9000Include.dbd
 #ifneq ($(NO_FORCE_CXX11),1)
 #USR_CXXFLAGS += --std=c++11
 #endif
+ifneq ($(NO_FORCE_CXX03),1)
 USR_CXXFLAGS += -std=c++03
+endif
 
 ifeq ($(BUILD_STRICT),1)
 USR_CXXFLAGS += -Wunused -Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations -Wno-variadic-macros

--- a/ek9000App/src/devEL50XX.cpp
+++ b/ek9000App/src/devEL50XX.cpp
@@ -29,7 +29,7 @@ struct EL50XXDpvt_t {
 static long el50xx_dev_report(int lvl);
 static long el50xx_init(int after);
 static long el50xx_init_record(void* precord);
-static long el50xx_get_ioint_info(int cmd, void *prec, IOSCANPVT *iopvt);
+static long el50xx_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt);
 static long el50xx_read_record(void* precord);
 
 struct devEL50XX_t {
@@ -40,8 +40,12 @@ struct devEL50XX_t {
 	DEVSUPFUN get_ioint_info;
 	DEVSUPFUN read_record;
 } devEL50XX = {
-	5, (DEVSUPFUN)el50xx_dev_report, (DEVSUPFUN)el50xx_init, el50xx_init_record,
-    (DEVSUPFUN)el50xx_get_ioint_info, el50xx_read_record,
+	5,
+	(DEVSUPFUN)el50xx_dev_report,
+	(DEVSUPFUN)el50xx_init,
+	el50xx_init_record,
+	(DEVSUPFUN)el50xx_get_ioint_info,
+	el50xx_read_record,
 };
 
 extern "C"
@@ -97,17 +101,16 @@ static long el50xx_init_record(void* precord) {
 	return 0;
 }
 
-static long el50xx_get_ioint_info(int cmd, void *prec, IOSCANPVT *iopvt)
-{
-    struct dbCommon *pRecord = static_cast<struct dbCommon *>(prec);
-    EL50XXDpvt_t* dpvt = static_cast<EL50XXDpvt_t*>(pRecord->dpvt);
+static long el50xx_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt) {
+	struct dbCommon* pRecord = static_cast<struct dbCommon*>(prec);
+	EL50XXDpvt_t* dpvt = static_cast<EL50XXDpvt_t*>(pRecord->dpvt);
 
-    if (!dpvt) {
-        return 1;
-    }
+	if (!dpvt) {
+		return 1;
+	}
 
-    *iopvt = dpvt->device->m_analog_io;
-    return 0;
+	*iopvt = dpvt->device->m_analog_io;
+	return 0;
 }
 
 static long el50xx_read_record(void* prec) {
@@ -124,8 +127,8 @@ static long el50xx_read_record(void* prec) {
 
 	/* Read into a buffer that's plenty big enough for any terminal type */
 	uint16_t data[32];
-	dpvt->terminal->getEK9000IO(MODBUS_READ_INPUT_REGISTERS, dpvt->terminal->m_inputStart,
-				 data, STRUCT_SIZE_TO_MODBUS_SIZE(dpvt->terminal->m_inputSize));
+	dpvt->terminal->getEK9000IO(MODBUS_READ_INPUT_REGISTERS, dpvt->terminal->m_inputStart, data,
+								STRUCT_SIZE_TO_MODBUS_SIZE(dpvt->terminal->m_inputSize));
 
 	/* Handle individual terminal pdo types */
 	switch (dpvt->tid) {
@@ -162,7 +165,7 @@ static long el50xx_read_record(void* prec) {
 static long el5042_dev_report(int lvl);
 static long el5042_init_record(void* prec);
 static long el5042_init(int after);
-static long el5042_get_ioint_info(int cmd, void *prec, IOSCANPVT *iopvt);
+static long el5042_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt);
 static long el5042_read_record(void* prec);
 
 struct devEL5042_t {
@@ -173,8 +176,12 @@ struct devEL5042_t {
 	DEVSUPFUN get_ioint_info;
 	DEVSUPFUN read_record;
 } devEL5042 = {
-	5, (DEVSUPFUN)el5042_dev_report, (DEVSUPFUN)el5042_init, el5042_init_record,
-    (DEVSUPFUN)el5042_get_ioint_info, el5042_read_record,
+	5,
+	(DEVSUPFUN)el5042_dev_report,
+	(DEVSUPFUN)el5042_init,
+	el5042_init_record,
+	(DEVSUPFUN)el5042_get_ioint_info,
+	el5042_read_record,
 };
 
 extern "C"
@@ -265,23 +272,21 @@ static long el5042_init(int) {
 	return 0;
 }
 
-
 /*
 ---------------------------------------
 Called to update the I/O interrupt data
 ---------------------------------------
 */
-static long el5042_get_ioint_info(int cmd, void *prec, IOSCANPVT *iopvt)
-{
-    struct dbCommon *pRecord = static_cast<struct dbCommon *>(prec);
-    EL5042Dpvt_t* dpvt = static_cast<EL5042Dpvt_t*>(pRecord->dpvt);
+static long el5042_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt) {
+	struct dbCommon* pRecord = static_cast<struct dbCommon*>(prec);
+	EL5042Dpvt_t* dpvt = static_cast<EL5042Dpvt_t*>(pRecord->dpvt);
 
-    if (!dpvt) {
-        return 1;
-    }
+	if (!dpvt) {
+		return 1;
+	}
 
-    *iopvt = dpvt->device->m_analog_io;
-    return 0;
+	*iopvt = dpvt->device->m_analog_io;
+	return 0;
 }
 
 /*
@@ -302,8 +307,8 @@ static long el5042_read_record(void* prec) {
 	/* Read the stuff */
 	uint16_t buf[32];
 	uint16_t loc = dpvt->terminal->m_inputStart + ((dpvt->channel - 1) * 3);
-	dpvt->terminal->getEK9000IO(MODBUS_READ_INPUT_REGISTERS, loc,
-				 buf, STRUCT_SIZE_TO_MODBUS_SIZE(sizeof(EL5042InputPDO_t)));
+	dpvt->terminal->getEK9000IO(MODBUS_READ_INPUT_REGISTERS, loc, buf,
+								STRUCT_SIZE_TO_MODBUS_SIZE(sizeof(EL5042InputPDO_t)));
 
 	/* Cast it to our pdo type */
 	pdo = reinterpret_cast<EL5042InputPDO_t*>(buf);


### PR DESCRIPTION
* @mamontironi reported that the EL5042 was no longer functional. It appears that it was not updated to support I/O interrupt: the database was set to I/O Intr but the source code may not have been touched. Aside from @mcb64 and @JJL772, she should also take a look at this PR
* Added flag for avoiding the `-std=c++03` flag as accelerator is on an old g++ (eb883d758167f62ec20ca46eb8648111193a20c3); compiles fine other than semi-concerning aliasing warnings not introduced in this PR (*)
* I think with this PR, all device support sets that define `read_record` now also define `get_ioint_info` - though that should probably be double-checked.
* Updated EL50xx to follow conventions of other device support source
* Reformatted with `clang-format` (and small tweak to script to fall back to `clang-format` if `clang-format-14` is unavailable)
* This appears to be working on the accelerator test rail now, though it only has one EL5042 and one terminal altogether
* Included test IOC reports the first encoder updating at I/O interrupt (non-scanned) rates, and reporting the raw encoder counts as expected:
```bash
$ camonitor ENC:1:1 ENC:1:2
ENC:1:1                        2022-02-03 09:22:27.528007 3179559
ENC:1:2                        2022-02-03 09:22:27.528008 401
ENC:1:1                        2022-02-03 09:22:42.134160 3179560
ENC:1:1                        2022-02-03 09:22:42.333657 3179559
```

(*)
<details>
<summary>Warnings</summary>

```
../devEL50XX.cpp: In function 'long int el5042_read_record(void*)':
../devEL50XX.cpp:325: warning: dereferencing pointer 'pdo' does break strict-aliasing rules
../devEL50XX.cpp:320: warning: dereferencing pointer 'pdo' does break strict-aliasing rules
../devEL50XX.cpp:317: warning: dereferencing pointer 'pdo' does break strict-aliasing rules
../devEL50XX.cpp:314: note: initialized from here
cc1plus: warning: dereferencing pointer 'pdo' does break strict-aliasing rules
../devEL50XX.cpp:314: note: initialized from here
../devEL50XX.cpp: In function 'long int el50xx_read_record(void*)':
../devEL50XX.cpp:142: warning: dereferencing pointer 'output' does break strict-aliasing rules
../devEL50XX.cpp:140: warning: dereferencing pointer 'output' does break strict-aliasing rules
../devEL50XX.cpp:138: warning: dereferencing pointer 'output' does break strict-aliasing rules
../devEL50XX.cpp:137: note: initialized from here
../devEL50XX.cpp:152: warning: dereferencing pointer 'output' does break strict-aliasing rules
../devEL50XX.cpp:150: warning: dereferencing pointer 'output' does break strict-aliasing rules
../devEL50XX.cpp:148: warning: dereferencing pointer 'output' does break strict-aliasing rules
../devEL50XX.cpp:147: note: initialized from here
cc1plus: warning: dereferencing pointer 'output' does break strict-aliasing rules
../devEL50XX.cpp:137: note: initialized from here
cc1plus: warning: dereferencing pointer 'output' does break strict-aliasing rules
../devEL50XX.cpp:147: note: initialized from here
```

</details>