### PR TITLE
Replace NUM_TERMINALS with ArraySize

### DIFF
--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -258,7 +258,7 @@ devEK9000Terminal* devEK9000Terminal::ProcessRecordName(const char* recname, int
 }
 
 void devEK9000Terminal::GetTerminalInfo(int termid, int& inp_size, int& out_size) {
-	for (int i = 0; i < NUM_TERMINALS; i++) {
+	for (int i = 0; i < ArraySize(g_pTerminalInfos); i++) {
 		if (g_pTerminalInfos[i]->m_nID == (uint32_t)termid) {
 			inp_size = g_pTerminalInfos[i]->m_nInputSize;
 			out_size = g_pTerminalInfos[i]->m_nOutputSize;
@@ -935,7 +935,7 @@ void ek9000ConfigureTerminal(const iocshArgBuf* args) {
 	}
 
 	int tid = 0;
-	for (int i = 0; i < NUM_TERMINALS; i++) {
+	for (int i = 0; i < ArraySize(g_pTerminalInfos); i++) {
 		if (strcmp(g_pTerminalInfos[i]->m_pString, type) == 0) {
 			tid = g_pTerminalInfos[i]->m_nID;
 			break;

--- a/ek9000App/src/ekUtil.cpp
+++ b/ek9000App/src/ekUtil.cpp
@@ -29,7 +29,7 @@ struct iocshHandles_t {
 std::vector<iocshHandles_t*> functions;
 
 const STerminalInfoConst_t* util::FindTerminal(unsigned int id) {
-	for (unsigned int i = 0; i < NUM_TERMINALS; i++)
+	for (unsigned int i = 0; i < ArraySize(g_pTerminalInfos); i++)
 		if (g_pTerminalInfos[i]->m_nID == id)
 			return g_pTerminalInfos[i];
 	return NULL;

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -48,6 +48,14 @@ public:
 
 #define AUTO_LOCK(x) CAutoLockWrapper<epicsMutex> __auto_lock(x)
 
+/**
+ * Determine size of an array
+ */
+template<class T, size_t N>
+size_t ArraySize(T(&arr)[N]) {
+	return N;
+}
+
 namespace util
 {
 /**

--- a/ek9000App/src/scripts/generate.py
+++ b/ek9000App/src/scripts/generate.py
@@ -99,9 +99,7 @@ try:
         header.add_define(name + "_INPUT_SIZE", str(insize))
         header.add_init_struct("STerminalInfoConst_t", name + "_Info", name + "_STRING", name + "_ID",
                                name + "_OUTPUT_SIZE", name + "_INPUT_SIZE", static=True, const=True)
-    header.newlines(1)
-    header.add_define("NUM_TERMINALS", str(count))
-    header.newlines(1)
+    header.newlines(2)
     header.add_array_variable("g_pTerminalInfos", "STerminalInfoConst_t*", vars, const=True, static=True)
 except KeyError as e:
     print("Malformed JSON:")


### PR DESCRIPTION
NUM_TERMINALS was generated and bad.

Closes #21 

Should also note that `g_pTerminalInfos` is a bit of a misnomer since it's not *really* a pointer. 

Let's also wait for the other PRs to be merged before merging this guy. I'll rebase this and regenerate terminals.h once the others are merge.d