### PR TITLE
FIX: EL2794 pdo out size + find_terminals tool

### DIFF
--- a/ek9000App/src/scripts/find_terminals.py
+++ b/ek9000App/src/scripts/find_terminals.py
@@ -248,8 +248,11 @@ def main(names_to_match: List[str], *, dump_json: bool = False):
             input_size, output_size = info.size_for_mapping(mapping)
             print(f"   * Mapping {mapping.name!r}")
 
+            total_input_size = sum(input_size or [0])
+            total_output_size = sum(output_size or [0])
             print(
-                f"     pdo_in_size={input_size} pdo_out_size={output_size}",
+                f"     pdo_in_size={total_input_size} entries={input_size} "
+                f"pdo_out_size={total_output_size} entries={output_size}",
                 end=" / "
             )
 
@@ -260,8 +263,8 @@ def main(names_to_match: List[str], *, dump_json: bool = False):
             to_compare = [
                 ("inputs", len(input_size)),
                 ("outputs", len(output_size)),
-                ("pdo_in_size", max(input_size or [0])),
-                ("pdo_out_size", max(output_size or [0])),
+                ("pdo_in_size", total_input_size),
+                ("pdo_out_size", total_output_size),
             ]
 
             differences = " ".join(

--- a/ek9000App/src/scripts/terminals.json
+++ b/ek9000App/src/scripts/terminals.json
@@ -318,7 +318,7 @@
 			"inputs": 0,
 			"outputs": 4,
 			"pdo_in_size": 0,
-			"pdo_out_size": 1
+			"pdo_out_size": 4
 		},
 		{
 			"name": "EL2808",

--- a/ek9000App/src/terminals.h
+++ b/ek9000App/src/terminals.h
@@ -573,7 +573,7 @@ static const STerminalInfoConst_t EL2124_Info = {
 //=========================================================//
 #define	EL2794_STRING	"EL2794"
 #define	EL2794_ID	2794
-#define	EL2794_OUTPUT_SIZE	1
+#define	EL2794_OUTPUT_SIZE	4
 #define	EL2794_INPUT_SIZE	0
 static const STerminalInfoConst_t EL2794_Info = {
 	EL2794_STRING,
@@ -1590,7 +1590,6 @@ static const STerminalInfoConst_t EL7047_Info = {
 	EL7047_INPUT_SIZE,
 };
 
-#define	NUM_TERMINALS	112
 
 static const STerminalInfoConst_t* g_pTerminalInfos[112] = {
 	&EL1001_Info,


### PR DESCRIPTION
Closes #23 

Always happens after a tag - remembering things that you forgot to check.
In this case, the EL2794 test rail will continue to work because it's at the end of the rail (and thus there are no mapped terminals after it and the offset specified here doesn't matter). For future rails including the terminal, it will likely make a difference.

I'll add the alternative mapping selection via the web tool to the wiki later as well.