### PR TITLE
FIX: default PREC to 3 for analog I/O records

### DIFF
--- a/ek9000App/Db/EL3001.template
+++ b/ek9000App/Db/EL3001.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3002.template
+++ b/ek9000App/Db/EL3002.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3004.template
+++ b/ek9000App/Db/EL3004.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3008.template
+++ b/ek9000App/Db/EL3008.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,6 +31,7 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):5")
@@ -36,6 +40,7 @@ record(ai,"$(TERMINAL):5")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):6")
@@ -44,6 +49,7 @@ record(ai,"$(TERMINAL):6")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):7")
@@ -52,6 +58,7 @@ record(ai,"$(TERMINAL):7")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):8")
@@ -60,5 +67,6 @@ record(ai,"$(TERMINAL):8")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3012.template
+++ b/ek9000App/Db/EL3012.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3014.template
+++ b/ek9000App/Db/EL3014.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3021.template
+++ b/ek9000App/Db/EL3021.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3022.template
+++ b/ek9000App/Db/EL3022.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3024.template
+++ b/ek9000App/Db/EL3024.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3041.template
+++ b/ek9000App/Db/EL3041.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3042.template
+++ b/ek9000App/Db/EL3042.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3044.template
+++ b/ek9000App/Db/EL3044.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3048.template
+++ b/ek9000App/Db/EL3048.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,6 +31,7 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):5")
@@ -36,6 +40,7 @@ record(ai,"$(TERMINAL):5")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):6")
@@ -44,6 +49,7 @@ record(ai,"$(TERMINAL):6")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):7")
@@ -52,6 +58,7 @@ record(ai,"$(TERMINAL):7")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):8")
@@ -60,5 +67,6 @@ record(ai,"$(TERMINAL):8")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3051.template
+++ b/ek9000App/Db/EL3051.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3052.template
+++ b/ek9000App/Db/EL3052.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3054.template
+++ b/ek9000App/Db/EL3054.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3058.template
+++ b/ek9000App/Db/EL3058.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,6 +31,7 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):5")
@@ -36,6 +40,7 @@ record(ai,"$(TERMINAL):5")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):6")
@@ -44,6 +49,7 @@ record(ai,"$(TERMINAL):6")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):7")
@@ -52,6 +58,7 @@ record(ai,"$(TERMINAL):7")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):8")
@@ -60,5 +67,6 @@ record(ai,"$(TERMINAL):8")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3061.template
+++ b/ek9000App/Db/EL3061.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3062.template
+++ b/ek9000App/Db/EL3062.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3064.template
+++ b/ek9000App/Db/EL3064.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3068.template
+++ b/ek9000App/Db/EL3068.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,6 +31,7 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):5")
@@ -36,6 +40,7 @@ record(ai,"$(TERMINAL):5")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):6")
@@ -44,6 +49,7 @@ record(ai,"$(TERMINAL):6")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):7")
@@ -52,6 +58,7 @@ record(ai,"$(TERMINAL):7")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):8")
@@ -60,5 +67,6 @@ record(ai,"$(TERMINAL):8")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3101.template
+++ b/ek9000App/Db/EL3101.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3102.template
+++ b/ek9000App/Db/EL3102.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3104.template
+++ b/ek9000App/Db/EL3104.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3111.template
+++ b/ek9000App/Db/EL3111.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3112.template
+++ b/ek9000App/Db/EL3112.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3114.template
+++ b/ek9000App/Db/EL3114.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3121.template
+++ b/ek9000App/Db/EL3121.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3122.template
+++ b/ek9000App/Db/EL3122.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3124.template
+++ b/ek9000App/Db/EL3124.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3141.template
+++ b/ek9000App/Db/EL3141.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3142.template
+++ b/ek9000App/Db/EL3142.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3144.template
+++ b/ek9000App/Db/EL3144.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3151.template
+++ b/ek9000App/Db/EL3151.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3152.template
+++ b/ek9000App/Db/EL3152.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3154.template
+++ b/ek9000App/Db/EL3154.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3161.template
+++ b/ek9000App/Db/EL3161.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3162.template
+++ b/ek9000App/Db/EL3162.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3164.template
+++ b/ek9000App/Db/EL3164.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3174.template
+++ b/ek9000App/Db/EL3174.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,6 +13,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):3")
@@ -20,6 +22,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):4")
@@ -28,5 +31,6 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3202.template
+++ b/ek9000App/Db/EL3202.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 
 record(ai,"$(TERMINAL):2")
@@ -12,5 +13,6 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL3311.template
+++ b/ek9000App/Db/EL3311.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "C")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 	field(ESLO, "1")
 }
 

--- a/ek9000App/Db/EL3312.template
+++ b/ek9000App/Db/EL3312.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "C")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 	field(ESLO, "1")
 }
 
@@ -13,6 +14,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "C")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 	field(ESLO, "1")
 }
 

--- a/ek9000App/Db/EL3314.template
+++ b/ek9000App/Db/EL3314.template
@@ -4,6 +4,7 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "C")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 	field(ESLO, "1")
 }
 
@@ -13,6 +14,7 @@ record(ai,"$(TERMINAL):2")
 	field(LINR, "LINEAR")
 	field(EGU, "C")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 	field(ESLO, "1")
 }
 
@@ -22,6 +24,7 @@ record(ai,"$(TERMINAL):3")
 	field(LINR, "LINEAR")
 	field(EGU, "C")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 	field(ESLO, "1")
 }
 
@@ -31,6 +34,7 @@ record(ai,"$(TERMINAL):4")
 	field(LINR, "LINEAR")
 	field(EGU, "C")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 	field(ESLO, "1")
 }
 

--- a/ek9000App/Db/EL3681.template
+++ b/ek9000App/Db/EL3681.template
@@ -4,5 +4,6 @@ record(ai,"$(TERMINAL):1")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
 	field(SCAN, "I/O Intr")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4001.template
+++ b/ek9000App/Db/EL4001.template
@@ -3,5 +3,6 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4002.template
+++ b/ek9000App/Db/EL4002.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,5 +11,6 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4004.template
+++ b/ek9000App/Db/EL4004.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,5 +27,6 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4008.template
+++ b/ek9000App/Db/EL4008.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,6 +27,7 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):5")
@@ -31,6 +35,7 @@ record(ao,"$(TERMINAL):5")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):6")
@@ -38,6 +43,7 @@ record(ao,"$(TERMINAL):6")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):7")
@@ -45,6 +51,7 @@ record(ao,"$(TERMINAL):7")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):8")
@@ -52,5 +59,6 @@ record(ao,"$(TERMINAL):8")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4011.template
+++ b/ek9000App/Db/EL4011.template
@@ -3,5 +3,6 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4012.template
+++ b/ek9000App/Db/EL4012.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,5 +11,6 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4014.template
+++ b/ek9000App/Db/EL4014.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,5 +27,6 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4018.template
+++ b/ek9000App/Db/EL4018.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,6 +27,7 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):5")
@@ -31,6 +35,7 @@ record(ao,"$(TERMINAL):5")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):6")
@@ -38,6 +43,7 @@ record(ao,"$(TERMINAL):6")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):7")
@@ -45,6 +51,7 @@ record(ao,"$(TERMINAL):7")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):8")
@@ -52,5 +59,6 @@ record(ao,"$(TERMINAL):8")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4021.template
+++ b/ek9000App/Db/EL4021.template
@@ -3,5 +3,6 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4022.template
+++ b/ek9000App/Db/EL4022.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,5 +11,6 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4024.template
+++ b/ek9000App/Db/EL4024.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,5 +27,6 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4028.template
+++ b/ek9000App/Db/EL4028.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,6 +27,7 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):5")
@@ -31,6 +35,7 @@ record(ao,"$(TERMINAL):5")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):6")
@@ -38,6 +43,7 @@ record(ao,"$(TERMINAL):6")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):7")
@@ -45,6 +51,7 @@ record(ao,"$(TERMINAL):7")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):8")
@@ -52,5 +59,6 @@ record(ao,"$(TERMINAL):8")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4031.template
+++ b/ek9000App/Db/EL4031.template
@@ -3,5 +3,6 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4032.template
+++ b/ek9000App/Db/EL4032.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,5 +11,6 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4034.template
+++ b/ek9000App/Db/EL4034.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,5 +27,6 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4038.template
+++ b/ek9000App/Db/EL4038.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,6 +27,7 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):5")
@@ -31,6 +35,7 @@ record(ao,"$(TERMINAL):5")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):6")
@@ -38,6 +43,7 @@ record(ao,"$(TERMINAL):6")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):7")
@@ -45,6 +51,7 @@ record(ao,"$(TERMINAL):7")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):8")
@@ -52,5 +59,6 @@ record(ao,"$(TERMINAL):8")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4102.template
+++ b/ek9000App/Db/EL4102.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,5 +11,6 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4104.template
+++ b/ek9000App/Db/EL4104.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,5 +27,6 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4112.template
+++ b/ek9000App/Db/EL4112.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,5 +11,6 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4114.template
+++ b/ek9000App/Db/EL4114.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,5 +27,6 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4122.template
+++ b/ek9000App/Db/EL4122.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,5 +11,6 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4132.template
+++ b/ek9000App/Db/EL4132.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,5 +11,6 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/Db/EL4134.template
+++ b/ek9000App/Db/EL4134.template
@@ -3,6 +3,7 @@ record(ao,"$(TERMINAL):1")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):2")
@@ -10,6 +11,7 @@ record(ao,"$(TERMINAL):2")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):3")
@@ -17,6 +19,7 @@ record(ao,"$(TERMINAL):3")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 
 record(ao,"$(TERMINAL):4")
@@ -24,5 +27,6 @@ record(ao,"$(TERMINAL):4")
 	field(DTYP, "EL40XX")
 	field(LINR, "LINEAR")
 	field(EGU, "Volts")
+	field(PREC, "3")
 }
 

--- a/ek9000App/src/scripts/generate.py
+++ b/ek9000App/src/scripts/generate.py
@@ -202,6 +202,7 @@ class Terminal():
         self.vals['LINR'] = 'LINEAR'
         self.vals['EGU'] = 'Volts'
         self.vals['SCAN'] = 'I/O Intr'
+        self.vals['PREC'] = '3'
 
     def set_default_longin(self):
         self.vals['EGU'] = 'Counts'
@@ -210,6 +211,7 @@ class Terminal():
     def set_default_ao(self):
         self.vals['LINR'] = 'LINEAR'
         self.vals['EGU'] = 'Volts'
+        self.vals['PREC'] = '3'
 
 
 subs = \


### PR DESCRIPTION
Pretty straightforward, addresses part of #30 

ADEL/MDEL is a bit more involved, as they'll need to be individually configured based on different terminal parameters.