### PR TITLE
FIX: interpret analog input values as int16

### DIFF
--- a/ek9000App/src/devEL3XXX.cpp
+++ b/ek9000App/src/devEL3XXX.cpp
@@ -131,7 +131,7 @@ struct EL30XXStandardInputPDO_t {
 	uint8_t _r2 : 6; // Last bit in this align is Sync error for EL31XX
 	uint8_t txpdo_state : 1;
 	uint8_t txpdo_toggle : 1;
-	uint16_t value;
+	int16_t value;	// Must be signed to accommodate bipolar terminals. Unsigned representation still defines range as 0-32767, so this is safe.
 };
 #pragma pack()
 
@@ -339,7 +339,7 @@ struct EL331XInputPDO_t {
 	uint8_t error : 1;
 	uint8_t txpdo_state : 1;
 	uint8_t txpdo_toggle : 1;
-	uint16_t value;
+	int16_t value;
 };
 
 struct EL3314_0010_InputPDO_t {
@@ -351,7 +351,7 @@ struct EL3314_0010_InputPDO_t {
 	uint8_t txpdo_state : 1;
 	uint8_t txpdo_toggle : 1;
 	uint8_t padding1 : 7; // Pad it out to byte boundary
-	uint16_t value;
+	int16_t value;
 };
 #pragma pack()
 


### PR DESCRIPTION
Both signed and unsigned representations behave like a signed 16-bit integer. In the case of unsigned, the value is limited to the range 0-32767, the former is limited to -32768-32767. As such, treating the values from the device as int16 (and thus sign extending it when assigning to RVAL) is the correct way of doing things.

MSB representation is still not handled in this PR.

Leaving as draft until I can find and test with a bipolar terminal! 