### PR TITLE
ek9k status and configuration records

### DIFF
--- a/ek9000App/Db/ek9000_status.db
+++ b/ek9000App/Db/ek9000_status.db
@@ -4,30 +4,34 @@
 
 record(longin,"$(EK9K):AnalogOutputSize")
 {
+	field(PINI,"YES")
 	field(EGU, "bytes")
 	field(INP, "@$(EK9K),0x1010")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):AnalogInputSize")
 {
+	field(PINI,"YES")
 	field(EGU, "bytes")
 	field(INP, "@$(EK9K),0x1011")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):DigitalInputSize")
 {
+	field(PINI,"YES")
 	field(EGU, "bits")
 	field(INP, "@$(EK9K),0x1012")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):DigitalOutputSize")
 {
+	field(PINI,"YES")
 	field(EGU, "bits")
 	field(INP, "@$(EK9K),0x1013")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):WatchdogExpTime")
@@ -35,77 +39,77 @@ record(longin,"$(EK9K):WatchdogExpTime")
 	field(SCAN, "10 second")
 	field(EGU, "ms")
 	field(INP, "@$(EK9K),0x1020")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):FallbacksTriggered")
 {
 	field(SCAN, "10 second")
 	field(INP, "@$(EK9K),0x1021")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):TCPConnections")
 {
 	field(SCAN, "10 second")
 	field(INP, "@$(EK9K),0x1022")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):HardwareVersion")
 {
 	field(PINI,"YES")
 	field(INP,"@$(EK9K),0x1030")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):SoftwareVersionMain")
 {
 	field(PINI,"YES")
 	field(INP,"@$(EK9K),0x1031")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):SoftwareVersionSub")
 {
 	field(PINI,"YES")
 	field(INP,"@$(EK9K),0x1032")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):SoftwareVersionBeta")
 {
 	field(PINI,"YES")
 	field(INP,"@$(EK9K),0x1033")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):SerialNumber")
 {
 	field(PINI,"YES")
 	field(INP,"@$(EK9K),0x1034")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):DayOfMfg")
 {
 	field(PINI,"YES")
 	field(INP,"@$(EK9K),0x1035")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):MonthOfMfg")
 {
 	field(PINI,"YES")
 	field(INP,"@$(EK9K),0x1036")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):YearOfMfg")
 {
 	field(PINI,"YES")
 	field(INP,"@$(EK9K),0x1037")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):EbusStatus")
@@ -116,13 +120,13 @@ record(longin,"$(EK9K):EbusStatus")
 	field(LOW, 0)
 	field(LSV, "MAJOR")
 	field(LLSV, "MAJOR")
-	field(DTYP, "EK9000ParamRO")
+	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longout,"$(EK9K):WatchdogTime")
 {
 	field(OUT,"@$(EK9K),0x1120")
-	field(DTYP, "EK9000ParamRW")
+	field(DTYP, "EK9000ConfigRW")
 	field(VAL, 1000)
 	field(PINI, "YES")
 }
@@ -130,7 +134,7 @@ record(longout,"$(EK9K):WatchdogTime")
 record(longout,"$(EK9K):WatchdogType")
 {
 	field(OUT,"@$(EK9K),0x1122")
-	field(DTYP, "EK9000ParamRW")
+	field(DTYP, "EK9000ConfigRW")
 	field(VAL, 1)
 	field(PINI, "YES")
 }
@@ -138,7 +142,7 @@ record(longout,"$(EK9K):WatchdogType")
 record(longout,"$(EK9K):FallbackMode")
 {
 	field(OUT,"@$(EK9K),0x1123")
-	field(DTYP, "EK9000ParamRW")
+	field(DTYP, "EK9000ConfigRW")
 	field(VAL, 0)
 	field(PINI, "YES")
 }
@@ -146,7 +150,7 @@ record(longout,"$(EK9K):FallbackMode")
 record(longout,"$(EK9K):WriteLock")
 {
 	field(OUT,"@$(EK9K),0x1124")
-	field(DTYP, "EK9000ParamRW")
+	field(DTYP, "EK9000ConfigRW")
 	field(VAL, 1)
 	field(PINI, "YES")
 }
@@ -154,5 +158,5 @@ record(longout,"$(EK9K):WriteLock")
 record(longout,"$(EK9K):EBusControl")
 {
 	field(OUT,"@$(EK9K),0x1140")
-	field(DTYP, "EK9000ParamRW")
+	field(DTYP, "EK9000ConfigRW")
 }

--- a/ek9000App/Db/ek9000_status.db
+++ b/ek9000App/Db/ek9000_status.db
@@ -6,7 +6,7 @@ record(longin,"$(EK9K):AnalogOutputSize")
 {
 	field(PINI,"YES")
 	field(EGU, "bytes")
-	field(INP, "@$(EK9K),0x1010")
+	field(INP, "@device=$(EK9K),type=analogOutputs")
 	field(DTYP, "EK9000ConfigRO")
 }
 
@@ -14,7 +14,7 @@ record(longin,"$(EK9K):AnalogInputSize")
 {
 	field(PINI,"YES")
 	field(EGU, "bytes")
-	field(INP, "@$(EK9K),0x1011")
+	field(INP, "@device=$(EK9K),type=analogInputs")
 	field(DTYP, "EK9000ConfigRO")
 }
 
@@ -22,7 +22,7 @@ record(longin,"$(EK9K):DigitalInputSize")
 {
 	field(PINI,"YES")
 	field(EGU, "bits")
-	field(INP, "@$(EK9K),0x1012")
+	field(INP, "@device=$(EK9K),type=digitalInputs")
 	field(DTYP, "EK9000ConfigRO")
 }
 
@@ -30,92 +30,92 @@ record(longin,"$(EK9K):DigitalOutputSize")
 {
 	field(PINI,"YES")
 	field(EGU, "bits")
-	field(INP, "@$(EK9K),0x1013")
+	field(INP, "@device=$(EK9K),type=digitalOutputs")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):WatchdogExpTime")
 {
-	field(SCAN, "10 second")
+	field(SCAN, "I/O Intr")
 	field(EGU, "ms")
-	field(INP, "@$(EK9K),0x1020")
+	field(INP, "@device=$(EK9K),type=wdtTime")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):FallbacksTriggered")
 {
-	field(SCAN, "10 second")
-	field(INP, "@$(EK9K),0x1021")
+	field(SCAN, "I/O Intr")
+	field(INP, "@device=$(EK9K),type=fallbacks")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):TCPConnections")
 {
-	field(SCAN, "10 second")
-	field(INP, "@$(EK9K),0x1022")
+	field(SCAN, "I/O Intr")
+	field(INP, "@device=$(EK9K),type=tcpConnections")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):HardwareVersion")
 {
 	field(PINI,"YES")
-	field(INP,"@$(EK9K),0x1030")
+	field(INP,"@device=$(EK9K),type=hardwareVer")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):SoftwareVersionMain")
 {
 	field(PINI,"YES")
-	field(INP,"@$(EK9K),0x1031")
+	field(INP,"@device=$(EK9K),type=softVerMain")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):SoftwareVersionSub")
 {
 	field(PINI,"YES")
-	field(INP,"@$(EK9K),0x1032")
+	field(INP,"@device=$(EK9K),type=softVerSub")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):SoftwareVersionBeta")
 {
 	field(PINI,"YES")
-	field(INP,"@$(EK9K),0x1033")
+	field(INP,"@device=$(EK9K),type=softVerBeta")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):SerialNumber")
 {
 	field(PINI,"YES")
-	field(INP,"@$(EK9K),0x1034")
+	field(INP,"@device=$(EK9K),type=serialNum")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):DayOfMfg")
 {
 	field(PINI,"YES")
-	field(INP,"@$(EK9K),0x1035")
+	field(INP,"@device=$(EK9K),type=prodDay")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):MonthOfMfg")
 {
 	field(PINI,"YES")
-	field(INP,"@$(EK9K),0x1036")
+	field(INP,"@device=$(EK9K),type=prodMonth")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):YearOfMfg")
 {
 	field(PINI,"YES")
-	field(INP,"@$(EK9K),0x1037")
+	field(INP,"@device=$(EK9K),type=prodYear")
 	field(DTYP, "EK9000ConfigRO")
 }
 
 record(longin,"$(EK9K):EbusStatus")
 {
-	field(INP,"@$(EK9K),0x1040")
-	field(SCAN,"1 second")
+	field(INP,"@device=$(EK9K),type=ebusStatus")
+	field(SCAN,"I/O Intr")
 	field(LOLO, 0)
 	field(LOW, 0)
 	field(LSV, "MAJOR")
@@ -125,7 +125,7 @@ record(longin,"$(EK9K):EbusStatus")
 
 record(longout,"$(EK9K):WatchdogTime")
 {
-	field(OUT,"@$(EK9K),0x1120")
+	field(OUT,"@device=$(EK9K),type=wdtTime")
 	field(DTYP, "EK9000ConfigRW")
 	field(VAL, 1000)
 	field(PINI, "YES")
@@ -133,7 +133,7 @@ record(longout,"$(EK9K):WatchdogTime")
 
 record(longout,"$(EK9K):WatchdogType")
 {
-	field(OUT,"@$(EK9K),0x1122")
+	field(OUT,"@device=$(EK9K),type=wdtType")
 	field(DTYP, "EK9000ConfigRW")
 	field(VAL, 1)
 	field(PINI, "YES")
@@ -141,7 +141,7 @@ record(longout,"$(EK9K):WatchdogType")
 
 record(longout,"$(EK9K):FallbackMode")
 {
-	field(OUT,"@$(EK9K),0x1123")
+	field(OUT,"@device=$(EK9K),type=wdtFallback")
 	field(DTYP, "EK9000ConfigRW")
 	field(VAL, 0)
 	field(PINI, "YES")
@@ -149,7 +149,7 @@ record(longout,"$(EK9K):FallbackMode")
 
 record(longout,"$(EK9K):WriteLock")
 {
-	field(OUT,"@$(EK9K),0x1124")
+	field(OUT,"@device=$(EK9K),type=writelock")
 	field(DTYP, "EK9000ConfigRW")
 	field(VAL, 1)
 	field(PINI, "YES")
@@ -157,6 +157,6 @@ record(longout,"$(EK9K):WriteLock")
 
 record(longout,"$(EK9K):EBusControl")
 {
-	field(OUT,"@$(EK9K),0x1140")
+	field(OUT,"@device=$(EK9K),type=ebusMode")
 	field(DTYP, "EK9000ConfigRW")
 }

--- a/ek9000App/op/ui/coupler.ui
+++ b/ek9000App/op/ui/coupler.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>EK9000 Coupler Settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="8" column="1">

--- a/ek9000App/op/ui/coupler.ui
+++ b/ek9000App/op/ui/coupler.ui
@@ -1,0 +1,651 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="PyDMFrame" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>589</width>
+    <height>520</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="8" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_5">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:AnalogInputSize</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:AnalogOutputSize</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_9">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:SerialNumber</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:FallbacksTriggered</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0" colspan="2" alignment="Qt::AlignHCenter">
+    <widget class="PyDMLabel" name="PyDMLabel_20">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Coupler Settings</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <widget class="PyDMEnumComboBox" name="PyDMEnumComboBox">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:WatchdogType</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>Write Telegram</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Telegram (Default)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Disable</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_7">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Hardware Version</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_8">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Mfg. Date (DD/MM/YYYY)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_25">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${EK9K}:SoftwareVersionMain</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignHCenter">
+      <widget class="PyDMLabel" name="PyDMLabel_24">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_23">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${EK9K}:SoftwareVersionSub</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_22">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_26">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${EK9K}:SoftwareVersionBeta</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="10" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_13">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Analog Outputs (bytes)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_6">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:DigitalInputSize</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Watchdog Mode</string>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_15">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${EK9K}:DayOfMfg</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_18">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>/</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_17">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${EK9K}:MonthOfMfg</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_19">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>/</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_16">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${EK9K}:YearOfMfg</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_9">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>EBus Status</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Watchdog Timeout (ms)</string>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:TCPConnections</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="PyDMEnumComboBox" name="PyDMEnumComboBox_4">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:EbusStatus</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>FAULT</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>OK</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="15" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:WatchdogTime</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="11" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:DigitalOutputSize</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_6">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Software Version</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2" alignment="Qt::AlignHCenter">
+    <widget class="PyDMLabel" name="PyDMLabel_21">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Coupler State</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="1">
+    <widget class="PyDMCheckbox" name="PyDMCheckbox">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:WriteLock</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_28">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>TCP Connections</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_12">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Digital Inputs (bits)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_27">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Serial Number</string>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_4">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Fallback Mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_10">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Fallbacks Triggered</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_14">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Digital Outputs (bits)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:HardwareVersion</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_3">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Writelock</string>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="1">
+    <widget class="PyDMEnumComboBox" name="PyDMEnumComboBox_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${EK9K}:FallbackMode</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>Set to Zero (Default)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Freeze</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Stop E-Bus</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel_11">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Analog Inputs (bytes)</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMCheckbox</class>
+   <extends>QCheckBox</extends>
+   <header>pydm.widgets.checkbox</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEnumComboBox</class>
+   <extends>QComboBox</extends>
+   <header>pydm.widgets.enum_combo_box</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMFrame</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.frame</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ek9000App/src/Makefile
+++ b/ek9000App/src/Makefile
@@ -19,6 +19,8 @@ endif
 
 ifeq ($(BUILD_STRICT),1)
 USR_CXXFLAGS += -Wunused -Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations -Wno-variadic-macros
+else
+USR_CXXFLAGS += -Werror=shadow -Wshadow
 endif
 
 ifeq ($(ENABLE_ASAN),1)

--- a/ek9000App/src/Makefile
+++ b/ek9000App/src/Makefile
@@ -18,7 +18,7 @@ USR_CXXFLAGS += -std=c++11
 endif
 
 ifeq ($(BUILD_STRICT),1)
-USR_CXXFLAGS += -Wunused -Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations -Wno-variadic-macros
+USR_CXXFLAGS += -Wunused -Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations -Wno-variadic-macros -Wno-unused-parameter
 else
 USR_CXXFLAGS += -Werror=shadow -Wshadow
 endif

--- a/ek9000App/src/Makefile
+++ b/ek9000App/src/Makefile
@@ -19,8 +19,6 @@ endif
 
 ifeq ($(BUILD_STRICT),1)
 USR_CXXFLAGS += -Wunused -Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations -Wno-variadic-macros -Wno-unused-parameter
-else
-USR_CXXFLAGS += -Werror=shadow -Wshadow
 endif
 
 ifeq ($(ENABLE_ASAN),1)

--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -144,9 +144,10 @@ void PollThreadFunc(void*) {
 				scanIoRequest(device->m_analog_io);
 			}
 			// Read status registers only after a ~1 second delay
-			if (((start.tv_sec + start.tv_usec / 1e6) - (last_read_status.tv_sec + last_read_status.tv_usec / 1e6)) >= 1.0) {
-				device->m_status_status = 
-					device->doModbusIO(0, MODBUS_READ_INPUT_REGISTERS, EK9000_STATUS_START, device->m_status_buf, ArraySize(device->m_status_buf));
+			if (((start.tv_sec + start.tv_usec / 1e6) - (last_read_status.tv_sec + last_read_status.tv_usec / 1e6)) >=
+				1.0) {
+				device->m_status_status = device->doModbusIO(0, MODBUS_READ_INPUT_REGISTERS, EK9000_STATUS_START,
+															 device->m_status_buf, ArraySize(device->m_status_buf));
 				scanIoRequest(device->m_status_io);
 				gettimeofday(&last_read_status, NULL);
 			}
@@ -1293,7 +1294,7 @@ static long ek9k_confli_read_record(void* prec) {
 			{
 				uint16_t buf;
 				err = dpvt->param.ek9k->doCoEIO(0, dpvt->param.pterm->m_terminalIndex, dpvt->param.index, 1, &buf,
-										  dpvt->param.subindex);
+												dpvt->param.subindex);
 				precord->val = static_cast<epicsInt64>(buf);
 				break;
 			}
@@ -1301,7 +1302,7 @@ static long ek9k_confli_read_record(void* prec) {
 			{
 				uint16_t buf;
 				err = dpvt->param.ek9k->doCoEIO(0, dpvt->param.pterm->m_terminalIndex, dpvt->param.index, 1, &buf,
-										  dpvt->param.subindex);
+												dpvt->param.subindex);
 				precord->val = static_cast<epicsInt64>(buf);
 				break;
 			}
@@ -1309,7 +1310,7 @@ static long ek9k_confli_read_record(void* prec) {
 			{
 				uint16_t buf;
 				err = dpvt->param.ek9k->doCoEIO(0, dpvt->param.pterm->m_terminalIndex, dpvt->param.index, 1, &buf,
-										  dpvt->param.subindex);
+												dpvt->param.subindex);
 				precord->val = static_cast<epicsInt64>(buf);
 				break;
 			}
@@ -1317,7 +1318,7 @@ static long ek9k_confli_read_record(void* prec) {
 			{
 				uint32_t buf;
 				err = dpvt->param.ek9k->doCoEIO(0, dpvt->param.pterm->m_terminalIndex, dpvt->param.index, 2,
-										  reinterpret_cast<uint16_t*>(&buf), dpvt->param.subindex);
+												reinterpret_cast<uint16_t*>(&buf), dpvt->param.subindex);
 				precord->val = static_cast<epicsInt64>(buf);
 				break;
 			}
@@ -1325,7 +1326,7 @@ static long ek9k_confli_read_record(void* prec) {
 			{
 				uint64_t buf;
 				err = dpvt->param.ek9k->doCoEIO(0, dpvt->param.pterm->m_terminalIndex, dpvt->param.index, 4,
-										  reinterpret_cast<uint16_t*>(&buf), dpvt->param.subindex);
+												reinterpret_cast<uint16_t*>(&buf), dpvt->param.subindex);
 				precord->val = static_cast<epicsInt64>(buf);
 				break;
 			}
@@ -1519,8 +1520,7 @@ bool CoE_ParseString(const char* str, ek9k_coe_param_t* param) {
 //-----------------------------------------------------------------//
 // EK9K RO configuration/status
 static long ek9k_status_init(int pass);
-template<class T>
-static long ek9k_status_init_record(void* prec); // Common init function for status/config records
+template <class T> static long ek9k_status_init_record(void* prec); // Common init function for status/config records
 static long ek9k_status_read_record(void* prec);
 static long ek9k_status_write_record(void* prec);
 static long ek9k_status_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt);
@@ -1531,7 +1531,7 @@ enum {
 	STATUS_RD = 0x1,
 	STATUS_WR = 0x2,
 	STATUS_RW = STATUS_RD | STATUS_WR,
-	STATUS_STATIC = 0x4,	/* These registers will never change during runtime, only need to read these once */
+	STATUS_STATIC = 0x4, /* These registers will never change during runtime, only need to read these once */
 };
 typedef int StatusFlags;
 
@@ -1541,29 +1541,27 @@ struct StatusReg {
 	StatusFlags flags;
 };
 
-CONSTEXPR StatusReg status_regs[] = {
-	{"analogOutputs", 0x1010, STATUS_RD | STATUS_STATIC},
-	{"analogInputs", 0x1011, STATUS_RD | STATUS_STATIC},
-	{"digitalOutputs", 0x1012, STATUS_RD | STATUS_STATIC},
-	{"digitalInputs", 0x1013, STATUS_RD | STATUS_STATIC},
-	{"fallbacks", 0x1021, STATUS_RD},
-	{"tcpConnections", 0x1022, STATUS_RD},
-	{"hardwareVer", 0x1030, STATUS_RD | STATUS_STATIC},
-	{"softVerMain", 0x1031, STATUS_RD | STATUS_STATIC},
-	{"softVerSub", 0x1032, STATUS_RD | STATUS_STATIC},
-	{"softVerBeta", 0x1033, STATUS_RD | STATUS_STATIC},
-	{"serialNum", 0x1034, STATUS_RD | STATUS_STATIC},
-	{"prodDay", 0x1035, STATUS_RD | STATUS_STATIC},
-	{"prodMonth", 0x1036, STATUS_RD | STATUS_STATIC},
-	{"prodYear", 0x1037, STATUS_RD | STATUS_STATIC},
-	{"ebusStatus", 0x1040, STATUS_RD},
-	{"wdtTime", 0x1120, STATUS_RW},
-	{"wdtReset", 0x1121, STATUS_RW},
-	{"wdtType", 0x1122, STATUS_RW},
-	{"wdtFallback", 0x1123, STATUS_RW},
-	{"writelock", 0x1124, STATUS_RW},
-	{"ebusMode", 0x1140, STATUS_RW}
-};
+CONSTEXPR StatusReg status_regs[] = {{"analogOutputs", 0x1010, STATUS_RD | STATUS_STATIC},
+									 {"analogInputs", 0x1011, STATUS_RD | STATUS_STATIC},
+									 {"digitalOutputs", 0x1012, STATUS_RD | STATUS_STATIC},
+									 {"digitalInputs", 0x1013, STATUS_RD | STATUS_STATIC},
+									 {"fallbacks", 0x1021, STATUS_RD},
+									 {"tcpConnections", 0x1022, STATUS_RD},
+									 {"hardwareVer", 0x1030, STATUS_RD | STATUS_STATIC},
+									 {"softVerMain", 0x1031, STATUS_RD | STATUS_STATIC},
+									 {"softVerSub", 0x1032, STATUS_RD | STATUS_STATIC},
+									 {"softVerBeta", 0x1033, STATUS_RD | STATUS_STATIC},
+									 {"serialNum", 0x1034, STATUS_RD | STATUS_STATIC},
+									 {"prodDay", 0x1035, STATUS_RD | STATUS_STATIC},
+									 {"prodMonth", 0x1036, STATUS_RD | STATUS_STATIC},
+									 {"prodYear", 0x1037, STATUS_RD | STATUS_STATIC},
+									 {"ebusStatus", 0x1040, STATUS_RD},
+									 {"wdtTime", 0x1120, STATUS_RW},
+									 {"wdtReset", 0x1121, STATUS_RW},
+									 {"wdtType", 0x1122, STATUS_RW},
+									 {"wdtFallback", 0x1123, STATUS_RW},
+									 {"writelock", 0x1124, STATUS_RW},
+									 {"ebusMode", 0x1140, STATUS_RW}};
 
 // Read-only status info (tcp connections, fallbacks triggered, etc.)
 struct devEK9000ConfigRO_t {
@@ -1574,7 +1572,12 @@ struct devEK9000ConfigRO_t {
 	DEVSUPFUN get_ioint_info;
 	DEVSUPFUN write_longout;
 } devEK9000ConfigRO = {
-	5, NULL, (DEVSUPFUN)ek9k_status_init, ek9k_status_init_record<longinRecord>, (DEVSUPFUN)ek9k_status_get_ioint_info, ek9k_status_read_record,
+	5,
+	NULL,
+	(DEVSUPFUN)ek9k_status_init,
+	ek9k_status_init_record<longinRecord>,
+	(DEVSUPFUN)ek9k_status_get_ioint_info,
+	ek9k_status_read_record,
 };
 
 epicsExportAddress(dset, devEK9000ConfigRO);
@@ -1588,7 +1591,12 @@ struct devEK9000ConfigRW_t {
 	DEVSUPFUN get_ioint_info;
 	DEVSUPFUN write_longout;
 } devEK9000ConfigRW = {
-	5, NULL, (DEVSUPFUN)ek9k_status_init, ek9k_status_init_record<longoutRecord>, (DEVSUPFUN)ek9k_status_get_ioint_info, ek9k_status_write_record,
+	5,
+	NULL,
+	(DEVSUPFUN)ek9k_status_init,
+	ek9k_status_init_record<longoutRecord>,
+	(DEVSUPFUN)ek9k_status_get_ioint_info,
+	ek9k_status_write_record,
 };
 
 epicsExportAddress(dset, devEK9000ConfigRW);
@@ -1605,8 +1613,7 @@ static const char* link_value(longoutRecord* rec) {
 	return rec->out.value.instio.string;
 }
 
-template<class T>
-static long ek9k_status_init_record(void* prec) {
+template <class T> static long ek9k_status_init_record(void* prec) {
 	T* precord = static_cast<T*>(prec);
 	precord->dpvt = calloc(1, sizeof(ek9k_param_t));
 	ek9k_param_t* dpvt = static_cast<ek9k_param_t*>(precord->dpvt);
@@ -1666,7 +1673,7 @@ static long ek9k_status_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt) {
 	longinRecord* rec = static_cast<longinRecord*>(prec);
 	ek9k_param_t* param = static_cast<ek9k_param_t*>(rec->dpvt);
 	if (!param->ek9k)
-			return 1;
+		return 1;
 
 	// Static parameters only need to be updated once on init, skip any updates later down the road.
 	if (param->flags & STATUS_STATIC)
@@ -1683,7 +1690,7 @@ bool ek9k_parse_string(const char* str, ek9k_param_t& param) {
 	LinkSpec_t spec;
 	if (!util::ParseLinkSpecification(str, INST_IO, spec))
 		return false;
-	
+
 	param.reg = 0;
 	param.flags = 0;
 
@@ -1691,7 +1698,8 @@ bool ek9k_parse_string(const char* str, ek9k_param_t& param) {
 		if (spec[i].first == "device") {
 			param.ek9k = devEK9000::FindDevice(spec[i].second.c_str());
 			if (!param.ek9k) {
-				epicsPrintf("Unable to find device '%s' specified in instio string '%s'\n", spec[i].second.c_str(), str);
+				epicsPrintf("Unable to find device '%s' specified in instio string '%s'\n", spec[i].second.c_str(),
+							str);
 				return false;
 			}
 		}
@@ -1718,4 +1726,3 @@ bool ek9k_parse_string(const char* str, ek9k_param_t& param) {
 
 	return true;
 }
-

--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -1714,8 +1714,30 @@ bool ek9k_parse_string(const char* str, ek9k_param_t& param) {
 				}
 			}
 			if (param.reg == 0) {
-				epicsPrintf("Malformed integer value '%s' in instio string '%s'\n", spec[i].second.c_str(), str);
+				epicsPrintf("Malformed instio string '%s', does not specify register\n", spec[i].second.c_str());
 				return false;
+			}
+		}
+		else if (spec[i].first == "addr") {
+			if (epicsParseInt32(spec[i].second.c_str(), &param.reg, 16, NULL) != 0) {
+				epicsStdoutPrintf("Malformed integer '%s' in instio string for key 'addr'\n", spec[i].second.c_str());
+				return false;
+			}
+		}
+		else if (spec[i].first == "flags") {
+			for (int n = 0; n < spec[i].second.length(); ++n) {
+				char c = spec[i].second[n];
+				if (c == 'r')
+					param.flags |= STATUS_RD;
+				else if (c == 'w')
+					param.flags |= STATUS_WR;
+				else if (c == 's')
+					param.flags |= STATUS_STATIC;
+				else {
+					epicsPrintf("Unknown status flag '%c' in instio string '%s' for key 'flags'\n", c,
+								spec[i].second.c_str());
+					return false;
+				}
 			}
 		}
 		else {

--- a/ek9000App/src/devEK9000.dbd
+++ b/ek9000App/src/devEK9000.dbd
@@ -35,5 +35,5 @@ device(longin, INST_IO, devEL5042, "EL5042")
 
 device(int64in, INST_IO, devEK9KCoERO, "devEK9KCoERO")
 device(int64out, INST_IO, devEK9KCoERW, "devEK9KCoERW")
-device(longin, INST_IO, devEK9000ConfigRO, "devEK9000ConfigRO")
-device(longout, INST_IO, devEK9000ConfigRW, "devEK9000ConfigRW")
+device(longin, INST_IO, devEK9000ConfigRO, "EK9000ConfigRO")
+device(longout, INST_IO, devEK9000ConfigRW, "EK9000ConfigRW")

--- a/ek9000App/src/devEK9000.h
+++ b/ek9000App/src/devEK9000.h
@@ -189,7 +189,7 @@ public:
 	int m_numTerms;
 
 	std::string m_name;
-	std::string m_portName;
+	std::string m_octetPortName;
 	std::string m_ip;
 
 	bool m_connected;

--- a/ek9000App/src/devEK9000.h
+++ b/ek9000App/src/devEK9000.h
@@ -88,9 +88,9 @@ enum {
 
 /* Buffered IO types */
 enum EIOType {
-	READ_ANALOG,	/* Analogous to MODBUS_READ_INPUT_REGISTER */
-	READ_DIGITAL,	/* Analogous to MODBUS_READ_DISCRETE_INPUTS */
-	READ_STATUS		/* For status registers (e.g. num TCP connections, hardware ver, etc) */
+	READ_ANALOG,  /* Analogous to MODBUS_READ_INPUT_REGISTER */
+	READ_DIGITAL, /* Analogous to MODBUS_READ_DISCRETE_INPUTS */
+	READ_STATUS	  /* For status registers (e.g. num TCP connections, hardware ver, etc) */
 };
 
 /* Forward decls */
@@ -218,6 +218,7 @@ public:
 	uint16_t m_digital_cnt;
 	/* Buffer for status info */
 	uint16_t m_status_buf[EK9000_STATUS_END - EK9000_STATUS_START + 1];
+
 public:
 	static devEK9000* FindDevice(const char* name);
 

--- a/ek9000App/src/devEL1XXX.cpp
+++ b/ek9000App/src/devEL1XXX.cpp
@@ -124,7 +124,7 @@ template <class RecordT> static long EL10XX_read_record(void* prec) {
 																// channel is 1-based index, m_inputStart is also
 																// 1-based, but modbus coils are 0-based, hence the -2
 	assert(num <= sizeof(buf));
-	status = dpvt->pterm->getEK9000IO(MODBUS_READ_DISCRETE_INPUTS, addr, buf, num);
+	status = dpvt->pterm->getEK9000IO(READ_DIGITAL, addr, buf, num);
 
 	/* Error states */
 	if (status) {

--- a/ek9000App/src/devEL2XXX.cpp
+++ b/ek9000App/src/devEL2XXX.cpp
@@ -52,7 +52,7 @@ template <class RecordT> static void EL20XX_WriteCallback(CALLBACK* callback) {
 	free(callback);
 
 	/* Check for invalid */
-	if (!dpvt->pterm) {
+	if (!util::DpvtValid(dpvt)) {
 		pRecord->pact = FALSE;
 		return;
 	}
@@ -63,7 +63,7 @@ template <class RecordT> static void EL20XX_WriteCallback(CALLBACK* callback) {
 
 		if (!lock.valid()) {
 			LOG_ERROR(dpvt->pdrv, "failed to obtain device lock\n");
-			recGblSetSevr(pRecord, WRITE_ALARM, INVALID_ALARM);
+			recGblSetSevr(pRecord, COMM_ALARM, INVALID_ALARM);
 			pRecord->pact = FALSE;
 			return;
 		}
@@ -92,14 +92,9 @@ template <class RecordT> static void EL20XX_WriteCallback(CALLBACK* callback) {
 
 	/* check for errors... */
 	if (status) {
-		recGblSetSevr(pRecord, WRITE_ALARM, INVALID_ALARM);
-		if (status > 0x100) {
-			LOG_WARNING(dpvt->pdrv, "EL20XX_WriteCallback(): %s\n", devEK9000::ErrorToString(EK_EMODBUSERR));
-			pRecord->pact = FALSE;
-			return;
-		}
-		LOG_WARNING(dpvt->pdrv, "EL20XX_WriteCallback(): %s\n", devEK9000::ErrorToString(status));
+		recGblSetSevr(pRecord, COMM_ALARM, INVALID_ALARM);
 		pRecord->pact = FALSE;
+		LOG_WARNING(dpvt->pdrv, "%s\n", devEK9000::ErrorToString(status));
 		return;
 	}
 

--- a/ek9000App/src/devEL3XXX.cpp
+++ b/ek9000App/src/devEL3XXX.cpp
@@ -204,7 +204,7 @@ static long EL30XX_read_record(void* prec) {
 
 	int status;
 
-	status = dpvt->pterm->getEK9000IO(MODBUS_READ_INPUT_REGISTERS,
+	status = dpvt->pterm->getEK9000IO(READ_ANALOG,
 									  dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 2), buf, 2);
 	spdo = reinterpret_cast<EL30XXStandardInputPDO_t*>(buf);
 	pRecord->rval = spdo->value;
@@ -286,7 +286,7 @@ static long EL36XX_read_record(void* prec) {
 	/* Lock mutex */
 	int status;
 
-	status = dpvt->pterm->getEK9000IO(MODBUS_READ_INPUT_REGISTERS,
+	status = dpvt->pterm->getEK9000IO(READ_ANALOG,
 									  dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 2), buf, 2);
 	pdo = reinterpret_cast<EL36XXInputPDO_t*>(buf);
 	pRecord->rval = pdo->inp;
@@ -382,7 +382,7 @@ static long EL331X_read_record(void* prec) {
 	int status;
 
 	int loc = dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 2);
-	status = dpvt->pterm->getEK9000IO(MODBUS_READ_INPUT_REGISTERS, loc, buf, 2);
+	status = dpvt->pterm->getEK9000IO(READ_ANALOG, loc, buf, 2);
 
 	pdo = reinterpret_cast<EL331XInputPDO_t*>(buf);
 	pRecord->rval = pdo->value;

--- a/ek9000App/src/devEL3XXX.cpp
+++ b/ek9000App/src/devEL3XXX.cpp
@@ -204,8 +204,7 @@ static long EL30XX_read_record(void* prec) {
 
 	int status;
 
-	status = dpvt->pterm->getEK9000IO(READ_ANALOG,
-									  dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 2), buf, 2);
+	status = dpvt->pterm->getEK9000IO(READ_ANALOG, dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 2), buf, 2);
 	spdo = reinterpret_cast<EL30XXStandardInputPDO_t*>(buf);
 	pRecord->rval = spdo->value;
 
@@ -286,8 +285,7 @@ static long EL36XX_read_record(void* prec) {
 	/* Lock mutex */
 	int status;
 
-	status = dpvt->pterm->getEK9000IO(READ_ANALOG,
-									  dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 2), buf, 2);
+	status = dpvt->pterm->getEK9000IO(READ_ANALOG, dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 2), buf, 2);
 	pdo = reinterpret_cast<EL36XXInputPDO_t*>(buf);
 	pRecord->rval = pdo->inp;
 

--- a/ek9000App/src/devEL50XX.cpp
+++ b/ek9000App/src/devEL50XX.cpp
@@ -161,7 +161,7 @@ static long el50xx_read_record(void* prec) {
 		EL5001Input_t el5001;
 		EL5002Input_t el5002;
 	} data;
-	dpvt->pterm->getEK9000IO(MODBUS_READ_INPUT_REGISTERS, dpvt->pterm->m_inputStart, reinterpret_cast<uint16_t*>(&data),
+	dpvt->pterm->getEK9000IO(READ_ANALOG, dpvt->pterm->m_inputStart, reinterpret_cast<uint16_t*>(&data),
 							 dpvt->pterm->m_inputSize);
 
 	/* Handle individual terminal pdo types */
@@ -253,7 +253,7 @@ static long el5042_read_record(void* prec) {
 	/* Read the stuff */
 	uint16_t buf[32];
 	uint16_t loc = dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 3);
-	dpvt->pterm->getEK9000IO(MODBUS_READ_INPUT_REGISTERS, loc, buf,
+	dpvt->pterm->getEK9000IO(READ_ANALOG, loc, buf,
 							 STRUCT_SIZE_TO_MODBUS_SIZE(sizeof(EL5042InputPDO_t)));
 
 	/* Cast it to our pdo type */

--- a/ek9000App/src/devEL50XX.cpp
+++ b/ek9000App/src/devEL50XX.cpp
@@ -253,8 +253,7 @@ static long el5042_read_record(void* prec) {
 	/* Read the stuff */
 	uint16_t buf[32];
 	uint16_t loc = dpvt->pterm->m_inputStart + ((dpvt->channel - 1) * 3);
-	dpvt->pterm->getEK9000IO(READ_ANALOG, loc, buf,
-							 STRUCT_SIZE_TO_MODBUS_SIZE(sizeof(EL5042InputPDO_t)));
+	dpvt->pterm->getEK9000IO(READ_ANALOG, loc, buf, STRUCT_SIZE_TO_MODBUS_SIZE(sizeof(EL5042InputPDO_t)));
 
 	/* Cast it to our pdo type */
 	pdo = reinterpret_cast<EL5042InputPDO_t*>(buf);

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -256,11 +256,6 @@ template <> inline bool setupCommonDpvt<aoRecord>(aoRecord* prec, TerminalDpvt_t
 	return setupCommonDpvt(prec->name, prec->out.value.instio.string, dpvt);
 }
 
-inline bool parseInt(const std::string& s, int& out) {
-	bool hex = s[0] == '0' && s[1] == 'x';
-	return epicsParseInt32(s.c_str(), &out, hex ? 16 : 10, NULL) == 0;
-}
-
 } // namespace util
 
 // Clear pre-C++20 concept hacks

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -204,7 +204,7 @@ concept RECORD_TYPE = detail::BASE_RECORD<T> &&(detail::INPUT_RECORD<T> || detai
 #endif
 
 inline bool DpvtValid(TerminalDpvt_t* dpvt) {
-	return dpvt && dpvt->pdrv;
+	return dpvt && dpvt->pdrv && dpvt->pterm;
 }
 
 /**

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -23,6 +23,7 @@
 #include <mbboDirectRecord.h>
 #include <asynDriver.h>
 #include <compilerSpecific.h>
+#include <epicsStdlib.h>
 
 /* STL includes */
 #include <string>
@@ -249,6 +250,12 @@ template <> inline bool setupCommonDpvt<mbboDirectRecord>(mbboDirectRecord* prec
 }
 template <> inline bool setupCommonDpvt<aoRecord>(aoRecord* prec, TerminalDpvt_t& dpvt) {
 	return setupCommonDpvt(prec->name, prec->out.value.instio.string, dpvt);
+}
+
+
+inline bool parseInt(const std::string& s, int& out) {
+	bool hex = s[0] == '0' && s[1] == 'x';
+	return epicsParseInt32(s.c_str(), &out, hex ? 16 : 10, NULL) == 0;
 }
 
 } // namespace util

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -44,7 +44,6 @@
 #define CONSTEXPR constexpr
 #define OVERRIDE override
 #define FINAL final
-#define MAYBE_UNUSED [[maybe_unused]]
 #define DELETE_CTOR(x)                                                                                                 \
 	x = delete /* Sucks! Mainly to prevent misuse of classes, if you need a deleted ctor for other reasons, just make  \
 				  it private. */
@@ -52,8 +51,13 @@
 #define CONSTEXPR static const
 #define OVERRIDE
 #define FINAL
-#define MAYBE_UNUSED
 #define DELETE_CTOR(x)
+#endif
+
+#if __cplusplus >= 201703L
+#define MAYBE_UNUSED [[maybe_unused]]
+#else
+#define MAYBE_UNUSED __attribute__((unused))
 #endif
 
 #undef UNUSED

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -252,7 +252,6 @@ template <> inline bool setupCommonDpvt<aoRecord>(aoRecord* prec, TerminalDpvt_t
 	return setupCommonDpvt(prec->name, prec->out.value.instio.string, dpvt);
 }
 
-
 inline bool parseInt(const std::string& s, int& out) {
 	bool hex = s[0] == '0' && s[1] == 'x';
 	return epicsParseInt32(s.c_str(), &out, hex ? 16 : 10, NULL) == 0;

--- a/iocBoot/iocEK9KTest/st.tpl
+++ b/iocBoot/iocEK9KTest/st.tpl
@@ -18,4 +18,6 @@ cd "${TOP}/iocBoot/${IOC}"
 
 $RECORDS$
 
+dbLoadRecords("../../db/ek9000_status.db", "EK9K=EK9K1")
+
 iocInit


### PR DESCRIPTION
These records were in the module before, but it needed some improvement. The main big change here is reading all status records in one go every ~1 second, rather than having each individually poll. Additionally, alarms will be set accordingly if status records could not be read, which should help us keep track of which devices are unresponsive and when they entered that state.

In the latest commit, some of the alarm and error handling has been cleaned up. Instead of setting `READ_ALARM`/`WRITE_ALARM` when I/O fails, it sets `COMM_ALARM`. For terminals with limits built-in, `HW_LIMIT_ALARM` is set when those are exceeded. This component probably needs some more in-depth review, I haven't been able to find any documentation on `COMM_ALARM` or the other alarm types except `READ_ALARM` and `WRITE_ALARM`.

I added a couple status/configuration screen as well, it looks like this:
![Screenshot_20230630_165753](https://github.com/slaclab/epics-ek9000/assets/19717056/277d2014-0197-44bc-a150-f50ddf8ac943)
Everything in the coupler state section is read-only. 
