### PR TITLE
Don't poll device if it's not connected

### DIFF
--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -110,12 +110,17 @@ void PollThreadFunc(void*) {
 				/* check connection every other loop */
 				bool connected = device->VerifyConnection();
 				if (!connected && device->m_connected) {
-					LOG_WARNING(device, "%s: Link status changed to DISCONNECTED\n", device->m_name.data());
+					epicsPrintf("%s: Link status changed to DISCONNECTED\n", device->m_name.data());
 					device->m_connected = false;
 				}
 				if (connected && !device->m_connected) {
-					LOG_WARNING(device, "%s: Link status changed to CONNECTED\n", device->m_name.data());
+					epicsPrintf("%s: Link status changed to CONNECTED\n", device->m_name.data());
 					device->m_connected = true;
+				}
+				/* Skip poll if we're not connected */
+				if (!device->m_connected) {
+					LOG_INFO(device, "%s: device not connected, skipping poll", device->m_name.data());
+					continue;
 				}
 				uint16_t buf = 1;
 				if (device->doModbusIO(0, MODBUS_WRITE_SINGLE_REGISTER, 0x1121, &buf, 1)) {

--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -110,11 +110,11 @@ void PollThreadFunc(void*) {
 				/* check connection every other loop */
 				bool connected = device->VerifyConnection();
 				if (!connected && device->m_connected) {
-					epicsPrintf("%s: Link status changed to DISCONNECTED\n", device->m_name.data());
+					LOG_WARNING(device, "%s: Link status changed to DISCONNECTED\n", device->m_name.data());
 					device->m_connected = false;
 				}
 				if (connected && !device->m_connected) {
-					epicsPrintf("%s: Link status changed to CONNECTED\n", device->m_name.data());
+					LOG_WARNING(device, "%s: Link status changed to CONNECTED\n", device->m_name.data());
 					device->m_connected = true;
 				}
 				/* Skip poll if we're not connected */
@@ -138,7 +138,6 @@ void PollThreadFunc(void*) {
 					device->doModbusIO(0, MODBUS_READ_INPUT_REGISTERS, 0, device->m_analog_buf, device->m_analog_cnt);
 				scanIoRequest(device->m_analog_io);
 			}
-			lock.unlock();
 		}
 		cnt = (cnt + 1) % 2;
 		gettimeofday(&finish, NULL);

--- a/ek9000App/src/devEL2XXX.cpp
+++ b/ek9000App/src/devEL2XXX.cpp
@@ -86,7 +86,7 @@ template <class RecordT> static void EL20XX_WriteCallback(CALLBACK* callback) {
 
 		/* Write to buffer */
 		/** The logic here: channel - 1 for a 0-based index, and subtract another 1 because modbus coils start at 0, and
-		* inputStart is 1-based **/
+		 * inputStart is 1-based **/
 		status = dpvt->pterm->doEK9000IO(MODBUS_WRITE_MULTIPLE_COILS, addr, buf, length);
 	}
 

--- a/ek9000App/src/devEL3XXX.cpp
+++ b/ek9000App/src/devEL3XXX.cpp
@@ -30,7 +30,6 @@
 
 #include "terminal_types.g.h"
 
-
 //======================================================//
 //
 //	Common analog input routines

--- a/ek9000App/src/devEL4XXX.cpp
+++ b/ek9000App/src/devEL4XXX.cpp
@@ -112,7 +112,7 @@ static void EL40XX_WriteCallback(CALLBACK* callback) {
 		/* Set buffer & do write */
 		uint16_t buf = (int16_t)pRecord->rval;
 		status = dpvt->pterm->doEK9000IO(MODBUS_WRITE_MULTIPLE_REGISTERS,
-											dpvt->pterm->m_outputStart + (dpvt->channel - 1), &buf, 1);
+										 dpvt->pterm->m_outputStart + (dpvt->channel - 1), &buf, 1);
 	}
 
 	pRecord->udf = FALSE;

--- a/ek9000App/src/devEL50XX.cpp
+++ b/ek9000App/src/devEL50XX.cpp
@@ -119,7 +119,6 @@ static long el50xx_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt) {
 	return 0;
 }
 
-
 static long el50xx_read_record(void* precord);
 
 struct devEL50XX_t {


### PR DESCRIPTION
* This should avoid unnecessary lock contention and log spam in the IOC shell, which was causing us to generate HUGE log files (>1G) 
* Includes some bonus cleanup for duplicate device support functions for analog input and encoder terminals

I'll validate this with my test rail under unsavory network conditions on Wednesday. 