### PR TITLE
FIX: incorrect usage of epicsParseInt

### DIFF
--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -217,7 +217,7 @@ devEK9000Terminal* devEK9000Terminal::ProcessRecordName(const char* recname, int
 		for (size_t i = len; i >= 0; i--) {
 			if (ret[i] == ':' && (size_t)i < len) {
 				ret[i] = '\0';
-				if (epicsParseInt32(ret + 1, outindex, 10, NULL) == 0)
+				if (util::parseNumber(ret + 1, *outindex, 10))
 					good = true;
 				break;
 			}
@@ -1504,16 +1504,16 @@ bool CoE_ParseString(const char* str, ek9k_coe_param_t* param) {
 	else
 		return false;
 
-	if (epicsParseInt32(buffers[1], &termid, 10, NULL) != 0)
+	if (!util::parseNumber(buffers[1], termid, 10))
 		return 1;
 	pterm = pcoupler->m_terms[termid - 1];
 
 	param->pterm = pterm;
 	param->ek9k = pcoupler;
-	if (epicsParseInt32(buffers[2], &param->index, 16, NULL) != 0)
+	if (!util::parseNumber(buffers[2], param->index, 16))
 		return 1;
 
-	if (epicsParseInt32(buffers[3], &param->subindex, 16, NULL) != 0)
+	if (!util::parseNumber(buffers[3], param->subindex, 16))
 		return 1;
 
 	return true;
@@ -1720,7 +1720,7 @@ bool ek9k_parse_string(const char* str, ek9k_param_t& param) {
 			}
 		}
 		else if (spec[i].first == "addr") {
-			if (epicsParseInt32(spec[i].second.c_str(), &param.reg, 16, NULL) != 0) {
+			if (!util::parseNumber(spec[i].second.c_str(), param.reg, 16)) {
 				epicsStdoutPrintf("Malformed integer '%s' in instio string for key 'addr'\n", spec[i].second.c_str());
 				return false;
 			}

--- a/ek9000App/src/ekUtil.cpp
+++ b/ek9000App/src/ekUtil.cpp
@@ -88,8 +88,8 @@ bool util::setupCommonDpvt(const char* recName, const char* inp, TerminalDpvt_t&
 		}
 		/* Terminal position in rail (1=first) */
 		else if (strcmp(param.first.c_str(), "pos") == 0) {
-			int term = 0;
-			bool ok = epicsParseInt32(param.second.c_str(), &term, 10, NULL) != 0;
+			epicsInt32 term = 0;
+			bool ok = parseNumber(param.second.c_str(), term, 10);
 
 			/* Max supported devices by the EK9K is 255 */
 			if (term < 0 || term > 255 || !ok) {
@@ -100,8 +100,8 @@ bool util::setupCommonDpvt(const char* recName, const char* inp, TerminalDpvt_t&
 		}
 		/* Channel number */
 		else if (strcmp(param.first.c_str(), "channel") == 0) {
-			int channel = 0;
-			bool ok = epicsParseInt32(param.second.c_str(), &channel, 10, NULL) != 0;
+			epicsInt32 channel = 0;
+			bool ok = parseNumber(param.second.c_str(), channel, 10);
 			/* No real max here, but I think it's good to limit this to 8k as nothing has this many channels */
 			if (channel < 0 || channel > 8192 || !ok) {
 				epicsPrintf("%s (when parsing %s): invalid channel: %i\n", function, recName, channel);
@@ -114,7 +114,7 @@ bool util::setupCommonDpvt(const char* recName, const char* inp, TerminalDpvt_t&
 			const char* tid = param.second.c_str();
 			if (!strncmp(tid, "EL", 2))
 				tid += 2;
-			if (epicsParseInt32(tid, &dpvt.terminalType, 10, NULL) != 0) {
+			if (parseNumber(tid, dpvt.terminalType, 10) == 0) {
 				epicsPrintf("%s (when parsing %s): unable to parse terminal ID from string '%s'\n", function, recName,
 							param.second.c_str());
 				return false;


### PR DESCRIPTION
Mistake on my part from #49, I wasn't paying close enough attention when switching to `epicsParseInt`... For my own sake, I wrote some helpers that should avoid this issue in the future.