### PR TITLE
optimizations and some fault tolerance

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -1,20 +1,67 @@
-#RELEASE Location of external products
+# RELEASE - Location of external support modules
+#
+# IF YOU CHANGE ANY PATHS in this file or make API changes to
+# any modules it refers to, you should do a "make rebuild" in
+# this application's top level directory.
+#
+# The EPICS build process does not check dependencies against
+# any files from outside the application, so it is safest to
+# rebuild it completely if any modules it depends on change.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it may ONLY contain definititions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
 
-# Default support and base settings. These are intentionally non-functional
-SUPPORT=/path/to/support/
-EPICS_BASE=/path/to/epics/base/
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ = $(MODULES)/seq-ver
 
-# Include local release file
--include $(TOP)/configure/RELEASE.local 
+-include $(TOP)/RELEASE_SITE
 
--include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
 
-# Modbus and ASYN modules are dependencies
-MODBUS=$(SUPPORT)/modbus
-ASYN=$(SUPPORT)/asyn-4-36
+#  ==========================================================
+# Define the version strings for all needed modules
+# Use naming pattern:
+#   FOO_MODULE_VERSION = R1.2
+# so scripts can extract version strings
+# Don't set your version to anything such as "test" that
+# could match a directory name.
+# ==========================================================
+ASYN_MODULE_VERSION=R4.39-1.0.1
+MODBUS_MODULE_VERSION=R3.2-1.0.1
+
+# ==========================================================
+# Define module paths using pattern
+# FOO = $(EPICS_MODULES)/foo/$(FOO_MODULE_VERSION)
+#  or
+# FOO = /Full/Path/To/Development/Version 
+# ==========================================================
+ASYN=/reg/g/pcds/epics/R7.0.2-2.0/modules/asyn/$(ASYN_MODULE_VERSION)
+MODBUS=/reg/g/pcds/epics/R7.0.2-2.0/modules/modbus/$(MODBUS_MODULE_VERSION)
 
 # Motor module only required for EL7XXX support
-MOTOR=$(SUPPORT)/motor-r7-2
+#MOTOR=$(EPICS_MODULES)/motor/$(MOTOR_MODULE_VERSION)
 
--include $(TOP)/configure/RELEASE.local 
--include $(TOP)/../configure/EPICS_BASE.$(EPICS_HOST_ARCH)
+# Override in RELEASE.local please!
+EPICS_BASE=$(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)
+
+# These lines allow developers to override these RELEASE settings
+# without having to modify this file directly.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
+-include $(TOP)/configure/RELEASE.local
+

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -14,7 +14,7 @@
 #  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
 #
 # This file is parsed by both GNUmake and an EPICS Perl script,
-# so it may ONLY contain definititions of paths to other support
+# so it may ONLY contain definitions of paths to other support
 # modules, variable definitions that are used in module paths,
 # and include statements that pull in other RELEASE files.
 # Variables may be used before their values have been set.
@@ -50,8 +50,8 @@ MODBUS_MODULE_VERSION=R3.2-1.0.1
 #  or
 # FOO = /Full/Path/To/Development/Version 
 # ==========================================================
-ASYN=/reg/g/pcds/epics/R7.0.2-2.0/modules/asyn/$(ASYN_MODULE_VERSION)
-MODBUS=/reg/g/pcds/epics/R7.0.2-2.0/modules/modbus/$(MODBUS_MODULE_VERSION)
+ASYN=$(EPICS_MODULES)/asyn/$(ASYN_MODULE_VERSION)
+MODBUS=$(EPICS_MODULES)/modbus/$(MODBUS_MODULE_VERSION)
 
 # Motor module only required for EL7XXX support
 #MOTOR=$(EPICS_MODULES)/motor/$(MOTOR_MODULE_VERSION)

--- a/ek9000App/src/Makefile
+++ b/ek9000App/src/Makefile
@@ -24,6 +24,9 @@ endif
 # So just disable those couple warnings to avoid spam (and so PEDANTIC=1 actually builds with -Werror
 USR_CXXFLAGS += -Wno-deprecated-declarations -Wno-unused-variable
 
+# Disable non-null compare, some macros have null checks and these generate a warning if `this` or a &ref makes its way in there
+USR_CXXFLAGS += -Wno-nonnull-compare
+
 # Records/Device support sources
 ek9000Support_SRCS += devEK9000.cpp
 ek9000Support_SRCS += devEL1XXX.cpp

--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -790,8 +790,9 @@ uint16_t devEK9000::ReadTerminalID(uint16_t index) {
 
 	memset(m_terminals, 0, sizeof(m_terminals));
 	// Read the terminal register space. 0x6000 will contain 9000, corresponding to the bus coupler.
-	// registers thereafter will contain a numeric ID corresponding to the terminal type. i.e. 0x6001 will contain 3064 if the second terminal is an EL3064
-	// read 125 registers in a loop, as that's the max number that can be read in a single modbus transaction
+	// registers thereafter will contain a numeric ID corresponding to the terminal type. i.e. 0x6001 will contain 3064
+	// if the second terminal is an EL3064 read 125 registers in a loop, as that's the max number that can be read in a
+	// single modbus transaction
 	for (int off = 0; off < TERMINAL_REGISTER_COUNT; off += 125) {
 		// Check if there are no further terminals on the rail, otherwise continue reading
 		if (off > 0 && m_terminals[off] == 0)

--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -789,7 +789,11 @@ uint16_t devEK9000::ReadTerminalID(uint16_t index) {
 		return m_terminals[index];
 
 	memset(m_terminals, 0, sizeof(m_terminals));
-	for (int off = 0; off < 255; off += 125) {
+	// Read the terminal register space. 0x6000 will contain 9000, corresponding to the bus coupler.
+	// registers thereafter will contain a numeric ID corresponding to the terminal type. i.e. 0x6001 will contain 3064 if the second terminal is an EL3064
+	// read 125 registers in a loop, as that's the max number that can be read in a single modbus transaction
+	for (int off = 0; off < TERMINAL_REGISTER_COUNT; off += 125) {
+		// Check if there are no further terminals on the rail, otherwise continue reading
 		if (off > 0 && m_terminals[off] == 0)
 			break;
 		const size_t toRead = util::clamp(ArraySize(m_terminals) - off, 0, 125);

--- a/ek9000App/src/devEK9000.h
+++ b/ek9000App/src/devEK9000.h
@@ -64,6 +64,8 @@
 #define EK9000_STATUS_EBUS_STATUS 0x1040
 #define EK9000_STATUS_END 0x1040
 
+#define TERMINAL_REGISTER_COUNT 0xFF
+
 /* This device's error types */
 enum {
 	EK_EOK = 0,			/* OK */
@@ -221,7 +223,7 @@ public:
 	uint16_t m_status_buf[EK9000_STATUS_END - EK9000_STATUS_START + 1];
 
 	/* Cache of terminal layout */
-	uint16_t m_terminals[0xFF];
+	uint16_t m_terminals[TERMINAL_REGISTER_COUNT];
 	bool m_readTerminals;
 
 public:

--- a/ek9000App/src/devEK9000.h
+++ b/ek9000App/src/devEK9000.h
@@ -61,6 +61,7 @@
 
 /* Beginning of the block of register space containing status info. Spans from 0x1010 <-> 0x1040 */
 #define EK9000_STATUS_START 0x1010
+#define EK9000_STATUS_EBUS_STATUS 0x1040
 #define EK9000_STATUS_END 0x1040
 
 /* This device's error types */
@@ -207,6 +208,7 @@ public:
 	IOSCANPVT m_digital_io;
 	IOSCANPVT m_status_io;
 
+	bool m_ebus_ok;
 	int m_analog_status;
 	int m_digital_status;
 	int m_status_status;
@@ -217,7 +219,7 @@ public:
 	uint16_t m_digital_cnt;
 	/* Buffer for status info */
 	uint16_t m_status_buf[EK9000_STATUS_END - EK9000_STATUS_START + 1];
-	
+
 	/* Cache of terminal layout */
 	uint16_t m_terminals[0xFF];
 	bool m_readTerminals;

--- a/ek9000App/src/devEK9000.h
+++ b/ek9000App/src/devEK9000.h
@@ -217,6 +217,10 @@ public:
 	uint16_t m_digital_cnt;
 	/* Buffer for status info */
 	uint16_t m_status_buf[EK9000_STATUS_END - EK9000_STATUS_START + 1];
+	
+	/* Cache of terminal layout */
+	uint16_t m_terminals[0xFF];
+	bool m_readTerminals;
 
 public:
 	static devEK9000* FindDevice(const char* name);
@@ -321,7 +325,7 @@ public:
 	int WriteWritelockMode(uint16_t mode);
 
 	/* Read terminal type */
-	int ReadTerminalID(uint16_t termid, uint16_t& termidout);
+	uint16_t ReadTerminalID(uint16_t index);
 
 	/* Poll the ek9000 until data is ready/error */
 	/* Return 0 for OK, 1 for error */

--- a/ek9000App/src/devEL1XXX.cpp
+++ b/ek9000App/src/devEL1XXX.cpp
@@ -53,7 +53,6 @@ template <class RecordT> static long EL10XX_init_record(void* precord) {
 	uint16_t termid = 0;
 
 	/* Get terminal */
-	const bool mbbi = util::is_same<RecordT, mbbiDirectRecord>::value;
 	if (!util::setupCommonDpvt<RecordT>(pRecord, *dpvt)) {
 		LOG_ERROR(dpvt->pdrv, "Unable to setup dpvt for record %s\n", pRecord->name);
 		return 1;
@@ -72,7 +71,7 @@ template <class RecordT> static long EL10XX_init_record(void* precord) {
 		}
 
 		/* Read termid */
-		dpvt->pdrv->ReadTerminalID(dpvt->pterm->m_terminalIndex, termid);
+		termid = dpvt->pdrv->ReadTerminalID(dpvt->pterm->m_terminalIndex);
 	}
 
 	pRecord->udf = FALSE;

--- a/ek9000App/src/devEL2XXX.cpp
+++ b/ek9000App/src/devEL2XXX.cpp
@@ -127,8 +127,6 @@ template <class RecordT> static long EL20XX_init_record(void* precord) {
 	pRecord->dpvt = util::allocDpvt();
 	TerminalDpvt_t* dpvt = (TerminalDpvt_t*)pRecord->dpvt;
 
-	const bool mbbo = util::is_same<RecordT, mbboDirectRecord>::value;
-
 	/* Grab terminal info */
 	if (!util::setupCommonDpvt<RecordT>(pRecord, *dpvt)) {
 		LOG_ERROR(dpvt->pdrv, "Unable to setup dpvt for %s\n", pRecord->name);
@@ -154,7 +152,7 @@ template <class RecordT> static long EL20XX_init_record(void* precord) {
 
 	/* Read terminal ID */
 	uint16_t termid = 0;
-	dpvt->pdrv->ReadTerminalID(dpvt->pterm->m_terminalIndex, termid);
+	termid = dpvt->pdrv->ReadTerminalID(dpvt->pterm->m_terminalIndex);
 
 	/* Verify terminal ID */
 	if (termid == 0 || termid != dpvt->pterm->m_terminalId) {

--- a/ek9000App/src/devEL3XXX.cpp
+++ b/ek9000App/src/devEL3XXX.cpp
@@ -81,7 +81,7 @@ static long EL3XXX_init_record(void* precord) {
 		}
 
 		/* Check that slave # is OK */
-		dpvt->pdrv->ReadTerminalID(dpvt->pterm->m_terminalIndex, termid);
+		termid = dpvt->pdrv->ReadTerminalID(dpvt->pterm->m_terminalIndex);
 	}
 
 	/* This is important; if the terminal id is different than what we want, report an error */

--- a/ek9000App/src/devEL4XXX.cpp
+++ b/ek9000App/src/devEL4XXX.cpp
@@ -155,7 +155,7 @@ static long EL40XX_init_record(void* record) {
 		}
 
 		/* Read terminal ID */
-		dpvt->pterm->m_device->ReadTerminalID(dpvt->pterm->m_terminalIndex, termid);
+		termid = dpvt->pterm->m_device->ReadTerminalID(dpvt->pterm->m_terminalIndex);
 	}
 
 	/* Verify terminal ID */

--- a/ek9000App/src/devEL50XX.cpp
+++ b/ek9000App/src/devEL50XX.cpp
@@ -99,7 +99,7 @@ static long el50xx_init_record(void* precord) {
 		}
 
 		/* Check that slave # is OK */
-		dpvt->pterm->m_device->ReadTerminalID(dpvt->pterm->m_terminalIndex, termid);
+		termid = dpvt->pterm->m_device->ReadTerminalID(dpvt->pterm->m_terminalIndex);
 	}
 
 	if (termid != dpvt->pterm->m_terminalId || termid == 0) {

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -117,6 +117,11 @@ template <class T, size_t N> size_t ArraySize(T (&arr)[N]) {
 namespace util
 {
 
+template<class T, class A, class B>
+inline T clamp(const T& val, const A& low, const B& high) {
+	return val < low ? low : (val > high ? high : val);
+}
+
 /**
  * Simple format string
  * TODO: When we upgrade to C++11, make this templated with a constant for string length

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -117,8 +117,7 @@ template <class T, size_t N> size_t ArraySize(T (&arr)[N]) {
 namespace util
 {
 
-template<class T, class A, class B>
-inline T clamp(const T& val, const A& low, const B& high) {
+template <class T, class A, class B> inline T clamp(const T& val, const A& low, const B& high) {
 	return val < low ? low : (val > high ? high : val);
 }
 

--- a/iocBoot/iocEK9KTest/st.tpl
+++ b/iocBoot/iocEK9KTest/st.tpl
@@ -11,7 +11,7 @@ ek9000Test_registerRecordDeviceDriver pdbbase
 
 # Configure the device (EK9K_NAME, IP, PORT, TERMINAL_COUNT)
 ek9000Configure("${EK9K}", "${IP}", ${PORT}, ${NUM_TERMS})
-asynSetTraceMask("${EK9K}", 0, 0x21)
+asynSetTraceMask("${EK9K}", 0, 0x21) # 0x21 = (ASYN_TRACE_WARNING | ASYN_TRACE_ERROR)
 
 ${CONFIGURE}
 

--- a/iocBoot/iocEK9KTest/st.tpl
+++ b/iocBoot/iocEK9KTest/st.tpl
@@ -11,6 +11,7 @@ ek9000Test_registerRecordDeviceDriver pdbbase
 
 # Configure the device (EK9K_NAME, IP, PORT, TERMINAL_COUNT)
 ek9000Configure("${EK9K}", "${IP}", ${PORT}, ${NUM_TERMS})
+asynSetTraceMask("${EK9K}", 0, 0x21)
 
 ${CONFIGURE}
 


### PR DESCRIPTION
Closes #53 

* Don't poll the device if E-Bus is in an error state. The device will reject all reads/writes to the PDO address space when this is the case.
* Only read terminal IDs once, cache them for later

Tested on `bhc-tst-ek9000`