### PR TITLE
MNT: add pre-commit hooks for clang-format and other checks

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -33,13 +33,10 @@ jobs:
     name: clang-format formatting check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: clang-format check
-        uses: jidicula/clang-format-action@v4.11.0
-        with:
-          clang-format-version: '16'
-          check-path: 'ek9000App'
-          exclude-regex: 'terminals.h'
+      - uses: actions/checkout@v3
+      - run: sudo apt-get update && sudo apt-get -y install clang-format-15
+      - run: CLANG_FORMAT=clang-format-15 CI=1 ./clang-format.sh
+
   
   scripts-check:
     name: Scripts Check

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -35,9 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: clang-format check
-        uses: jidicula/clang-format-action@v4.8.0
+        uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: '14'
+          clang-format-version: '16'
           check-path: 'ek9000App'
           exclude-regex: 'terminals.h'
   

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: no-commit-to-branch
+      - id: check-merge-conflict
+      - id: check-json
+      - id: check-symlinks
+      - id: fix-byte-order-marker
+      - id: check-ast
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.6
+    hooks:
+      - id: clang-format
+        types_or: [c++, c]

--- a/clang-format.sh
+++ b/clang-format.sh
@@ -1,5 +1,9 @@
 #!/bin/bash 
 
-CLANG_FMT=$(which clang-format-14 || echo "clang-format")
+[ -z "$CLANG_FORMAT" ] && CLANG_FORMAT=clang-format
 
-$CLANG_FMT -i $(find . -iname "*.cpp" -o -iname "*.h")
+if [[ $CI -eq 1 ]]; then
+    ARGS="-Werror --dry-run"
+fi
+
+$CLANG_FORMAT $ARGS -i $(find . -iname "*.cpp" -o -iname "*.h")

--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -41,7 +41,7 @@
 #include <dbStaticLib.h>
 
 /* Modbus or asyn includes */
-//#include <drvModbusAsyn.h>
+// #include <drvModbusAsyn.h>
 #include <drvAsynIPPort.h>
 #include <modbusInterpose.h>
 

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -168,15 +168,11 @@ namespace util
 #if __cplusplus >= 201103L
 using std::is_same;
 #else
-template <class T, class U> struct is_same {
-	static bool value;
-};
+template <class T, class U> struct is_same { static bool value; };
 
 template <class T, class U> bool is_same<T, U>::value = false;
 
-template <class T> struct is_same<T, T> {
-	static bool value;
-};
+template <class T> struct is_same<T, T> { static bool value; };
 
 template <class T> bool is_same<T, T>::value = true;
 #endif
@@ -204,7 +200,7 @@ concept INPUT_RECORD = requires(T a) {
 } // namespace detail
 
 template <typename T>
-concept RECORD_TYPE = detail::BASE_RECORD<T> && (detail::INPUT_RECORD<T> || detail::OUTPUT_RECORD<T>);
+concept RECORD_TYPE = detail::BASE_RECORD<T> &&(detail::INPUT_RECORD<T> || detail::OUTPUT_RECORD<T>);
 
 template <typename T>
 concept NUMERIC_TYPE = std::same_as<T, epicsInt32> || std::same_as<T, epicsUInt32> || std::same_as<T, epicsInt16> ||

--- a/ek9000App/src/ekUtil.h
+++ b/ek9000App/src/ekUtil.h
@@ -168,11 +168,15 @@ namespace util
 #if __cplusplus >= 201103L
 using std::is_same;
 #else
-template <class T, class U> struct is_same { static bool value; };
+template <class T, class U> struct is_same {
+	static bool value;
+};
 
 template <class T, class U> bool is_same<T, U>::value = false;
 
-template <class T> struct is_same<T, T> { static bool value; };
+template <class T> struct is_same<T, T> {
+	static bool value;
+};
 
 template <class T> bool is_same<T, T>::value = true;
 #endif
@@ -200,7 +204,7 @@ concept INPUT_RECORD = requires(T a) {
 } // namespace detail
 
 template <typename T>
-concept RECORD_TYPE = detail::BASE_RECORD<T> &&(detail::INPUT_RECORD<T> || detail::OUTPUT_RECORD<T>);
+concept RECORD_TYPE = detail::BASE_RECORD<T> && (detail::INPUT_RECORD<T> || detail::OUTPUT_RECORD<T>);
 
 template <typename T>
 concept NUMERIC_TYPE = std::same_as<T, epicsInt32> || std::same_as<T, epicsUInt32> || std::same_as<T, epicsInt16> ||


### PR DESCRIPTION
Pretty straightforward PR, add some pre-commit hooks to avoid annoying `STY: clang-format` commits.