### PR TITLE
FIX: el3681 PDO size and layout

### DIFF
--- a/ek9000App/src/scripts/terminals.json
+++ b/ek9000App/src/scripts/terminals.json
@@ -1032,8 +1032,8 @@
 			"type": "AnalogIn",
 			"inputs": 1,
 			"outputs": 1,
-			"pdo_in_size": 3,
-			"pdo_out_size": 2,
+			"pdo_in_size": 4,
+			"pdo_out_size": 1,
 			"dtyp": "EL36XX"
 		},
 		{

--- a/ek9000App/src/terminal_types.g.h
+++ b/ek9000App/src/terminal_types.g.h
@@ -1428,9 +1428,9 @@ struct EL3311_t FINAL : terminal_t {
 struct EL3681_t FINAL : terminal_t {
 	static const uint32_t ID = 3681;
 	static const uint16_t NUM_INPUTS = 1;
-	static const uint16_t INPUT_SIZE = 3;
+	static const uint16_t INPUT_SIZE = 4;
 	static const uint16_t NUM_OUTPUTS = 1;
-	static const uint16_t OUTPUT_SIZE = 2;
+	static const uint16_t OUTPUT_SIZE = 1;
 	EL3681_t() {
 		str = "EL3681";
 		id = ID;


### PR DESCRIPTION
Output size is 2 bytes, input size is 8 bytes. Both were wrong apparently.

Closes #58

