### PR TITLE
FIX: Revert "ENH: enable USE_TYPED_DSET and convert all dsets to it"

### DIFF
--- a/ek9000App/src/Makefile
+++ b/ek9000App/src/Makefile
@@ -27,9 +27,6 @@ USR_CXXFLAGS += -Wno-deprecated-declarations -Wno-unused-variable
 # Disable non-null compare, some macros have null checks and these generate a warning if `this` or a &ref makes its way in there
 USR_CXXFLAGS += -Wno-nonnull-compare
 
-# Enable typed dset & rset (rset to silence warnings)
-USR_CPPFLAGS += -DUSE_TYPED_DSET=1 -DUSE_TYPED_RSET=1
-
 # Records/Device support sources
 ek9000Support_SRCS += devEK9000.cpp
 ek9000Support_SRCS += devEL1XXX.cpp

--- a/ek9000App/src/devEL1XXX.cpp
+++ b/ek9000App/src/devEL1XXX.cpp
@@ -46,7 +46,7 @@ static inline void type_specific_setup(mbbiDirectRecord* record, uint16_t numbit
 	record->shft = 0;
 }
 
-template <class RecordT> static long EL10XX_init_record(dbCommon* precord) {
+template <class RecordT> static long EL10XX_init_record(void* precord) {
 	RecordT* pRecord = (RecordT*)precord;
 	pRecord->dpvt = util::allocDpvt();
 	TerminalDpvt_t* dpvt = (TerminalDpvt_t*)pRecord->dpvt;
@@ -84,7 +84,7 @@ template <class RecordT> static long EL10XX_init_record(dbCommon* precord) {
 	return 0;
 }
 
-static long EL10XX_get_ioint_info(int cmd, dbCommon* prec, IOSCANPVT* iopvt) {
+static long EL10XX_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt) {
 	UNUSED(cmd);
 	struct dbCommon* pRecord = static_cast<struct dbCommon*>(prec);
 	TerminalDpvt_t* dpvt = static_cast<TerminalDpvt_t*>(pRecord->dpvt);
@@ -101,7 +101,8 @@ static inline void set_mbbi_rval(mbbiDirectRecord* record, uint32_t val) {
 	record->rval = (val >> record->shft) & record->mask;
 }
 
-template <class RecordT> static long EL10XX_read_record(RecordT* pRecord) {
+template <class RecordT> static long EL10XX_read_record(void* prec) {
+	RecordT* pRecord = (RecordT*)prec;
 	TerminalDpvt_t* dpvt = (TerminalDpvt_t*)pRecord->dpvt;
 
 	/* Check for invalid */
@@ -145,34 +146,38 @@ template <class RecordT> static long EL10XX_read_record(RecordT* pRecord) {
 	return 0;
 }
 
-bidset devEL10XX = {
-	{
-		5,
-		EL10XX_dev_report,
-		EL10XX_init,
-		EL10XX_init_record<biRecord>,
-		EL10XX_get_ioint_info,
-	},
-	EL10XX_read_record<biRecord>,
+struct devEL10XX_t {
+	long number;
+	DEVSUPFUN dev_report;
+	DEVSUPFUN init;
+	DEVSUPFUN init_record;
+	DEVSUPFUN get_ioint_info;
+	DEVSUPFUN read_record;
+} devEL10XX = {
+	5,
+	(DEVSUPFUN)EL10XX_dev_report,
+	(DEVSUPFUN)EL10XX_init,
+	(DEVSUPFUN)EL10XX_init_record<biRecord>,
+	(DEVSUPFUN)EL10XX_get_ioint_info,
+	(DEVSUPFUN)EL10XX_read_record<biRecord>,
 };
 
-extern "C"
-{
-	epicsExportAddress(dset, devEL10XX);
-}
+epicsExportAddress(dset, devEL10XX);
 
-mbbidirectdset devEL10XX_mbbiDirect = {
-	{
-		5,
-		EL10XX_dev_report,
-		EL10XX_init,
-		EL10XX_init_record<mbbiDirectRecord>,
-		EL10XX_get_ioint_info,
-	},
-	EL10XX_read_record<mbbiDirectRecord>,
+struct devEL10XXmbbi_t {
+	long number;
+	DEVSUPFUN dev_report;
+	DEVSUPFUN init;
+	DEVSUPFUN init_record;
+	DEVSUPFUN get_ioint_info;
+	DEVSUPFUN read_record;
+} devEL10XX_mbbiDirect = {
+	5,
+	(DEVSUPFUN)EL10XX_dev_report,
+	(DEVSUPFUN)EL10XX_init,
+	(DEVSUPFUN)EL10XX_init_record<mbbiDirectRecord>,
+	(DEVSUPFUN)EL10XX_get_ioint_info,
+	(DEVSUPFUN)EL10XX_read_record<mbbiDirectRecord>,
 };
 
-extern "C"
-{
-	epicsExportAddress(dset, devEL10XX_mbbiDirect);
-}
+epicsExportAddress(dset, devEL10XX_mbbiDirect);

--- a/ek9000App/src/devEL2XXX.cpp
+++ b/ek9000App/src/devEL2XXX.cpp
@@ -122,7 +122,7 @@ static inline void type_specific_setup(mbboDirectRecord* record, int16_t numbits
 	record->shft = 0;
 }
 
-template <class RecordT> static long EL20XX_init_record(dbCommon* precord) {
+template <class RecordT> static long EL20XX_init_record(void* precord) {
 	RecordT* pRecord = (RecordT*)precord;
 	pRecord->dpvt = util::allocDpvt();
 	TerminalDpvt_t* dpvt = (TerminalDpvt_t*)pRecord->dpvt;
@@ -162,7 +162,7 @@ template <class RecordT> static long EL20XX_init_record(dbCommon* precord) {
 	return 0;
 }
 
-template <class T> static long EL20XX_write_record(T* precord) {
+template <class T> static long EL20XX_write_record(void* precord) {
 	T* prec = (T*)precord;
 	if (prec->pact)
 		prec->pact = FALSE;
@@ -180,35 +180,31 @@ struct devEL20XX_t {
 	DEVSUPFUN init_record;
 	DEVSUPFUN get_ioint_info;
 	DEVSUPFUN write_record;
-};
-bodset devEL20XX = {
-	{
-		5,
-		EL20XX_dev_report,
-		EL20XX_init,
-		EL20XX_init_record<boRecord>,
-		NULL,
-	},
-	EL20XX_write_record<boRecord>,
+} devEL20XX = {
+	5,
+	(DEVSUPFUN)EL20XX_dev_report,
+	(DEVSUPFUN)EL20XX_init,
+	(DEVSUPFUN)EL20XX_init_record<boRecord>,
+	NULL,
+	(DEVSUPFUN)EL20XX_write_record<boRecord>,
 };
 
-extern "C"
-{
-	epicsExportAddress(dset, devEL20XX);
-}
+epicsExportAddress(dset, devEL20XX);
 
-mbbodirectdset devEL20XX_mbboDirect = {
-	{
-		5,
-		EL20XX_dev_report,
-		EL20XX_init,
-		EL20XX_init_record<mbboDirectRecord>,
-		NULL,
-	},
-	EL20XX_write_record<mbboDirectRecord>,
+struct {
+	long number;
+	DEVSUPFUN dev_report;
+	DEVSUPFUN init;
+	DEVSUPFUN init_record;
+	DEVSUPFUN get_ioint_info;
+	DEVSUPFUN write_record;
+} devEL20XX_mbboDirect = {
+	5,
+	(DEVSUPFUN)EL20XX_dev_report,
+	(DEVSUPFUN)EL20XX_init,
+	(DEVSUPFUN)EL20XX_init_record<mbboDirectRecord>,
+	NULL,
+	(DEVSUPFUN)EL20XX_write_record<mbboDirectRecord>,
 };
 
-extern "C"
-{
-	epicsExportAddress(dset, devEL20XX_mbboDirect);
-}
+epicsExportAddress(dset, devEL20XX_mbboDirect);

--- a/ek9000App/src/devEL3XXX.cpp
+++ b/ek9000App/src/devEL3XXX.cpp
@@ -38,11 +38,11 @@
 
 static long EL3XXX_dev_report(int interest);
 static long EL3XXX_init(int after);
-static long EL3XXX_init_record(dbCommon* precord);
-static long EL3XXX_get_ioint_info(int cmd, dbCommon* prec, IOSCANPVT* iopvt);
-static long EL3XXX_linconv(aiRecord* precord, int after);
+static long EL3XXX_init_record(void* precord);
+static long EL3XXX_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt);
+static long EL3XXX_linconv(void* precord, int after);
 
-static long EL3XXX_linconv(aiRecord*, int) {
+static long EL3XXX_linconv(void*, int) {
 	return 0;
 }
 
@@ -54,8 +54,8 @@ static long EL3XXX_init(int) {
 	return 0;
 }
 
-static long EL3XXX_init_record(dbCommon* precord) {
-	aiRecord* pRecord = reinterpret_cast<aiRecord*>(precord);
+static long EL3XXX_init_record(void* precord) {
+	aiRecord* pRecord = static_cast<aiRecord*>(precord);
 	pRecord->dpvt = util::allocDpvt();
 	TerminalDpvt_t* dpvt = static_cast<TerminalDpvt_t*>(pRecord->dpvt);
 	uint16_t termid = 0;
@@ -98,7 +98,7 @@ static long EL3XXX_init_record(dbCommon* precord) {
 //	EL30XX Device support
 //
 //======================================================//
-static long EL30XX_read_record(aiRecord* precord);
+static long EL30XX_read_record(void* precord);
 
 struct devEL30XX_t {
 	long number;
@@ -108,23 +108,17 @@ struct devEL30XX_t {
 	DEVSUPFUN get_ioint_info;
 	DEVSUPFUN read_record;
 	DEVSUPFUN linconv;
-};
-aidset devEL30XX = {
-	{
-		6,
-		EL3XXX_dev_report,
-		EL3XXX_init,
-		EL3XXX_init_record,
-		EL3XXX_get_ioint_info,
-	},
-	EL30XX_read_record,
-	EL3XXX_linconv,
+} devEL30XX = {
+	6,
+	(DEVSUPFUN)EL3XXX_dev_report,
+	(DEVSUPFUN)EL3XXX_init,
+	(DEVSUPFUN)EL3XXX_init_record,
+	(DEVSUPFUN)EL3XXX_get_ioint_info,
+	(DEVSUPFUN)EL30XX_read_record,
+	(DEVSUPFUN)EL3XXX_linconv,
 };
 
-extern "C"
-{
-	epicsExportAddress(dset, devEL30XX);
-}
+epicsExportAddress(dset, devEL30XX);
 
 #pragma pack(1)
 // This PDO type applies to EL30XX, EL31XX and EL32XX. For 31XX and 32XX some align bits are interpreted differently.
@@ -184,8 +178,9 @@ DEFINE_SINGLE_CHANNEL_INPUT_PDO(EL30XXStandardInputPDO_t, EL3164);
 DEFINE_SINGLE_CHANNEL_INPUT_PDO(EL30XXStandardInputPDO_t, EL3174);
 DEFINE_SINGLE_CHANNEL_INPUT_PDO(EL30XXStandardInputPDO_t, EL3202);
 
-static long EL3XXX_get_ioint_info(int cmd, dbCommon* pRecord, IOSCANPVT* iopvt) {
+static long EL3XXX_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt) {
 	UNUSED(cmd);
+	struct dbCommon* pRecord = static_cast<struct dbCommon*>(prec);
 	TerminalDpvt_t* dpvt = static_cast<TerminalDpvt_t*>(pRecord->dpvt);
 	if (!util::DpvtValid(dpvt))
 		return 1;
@@ -194,7 +189,7 @@ static long EL3XXX_get_ioint_info(int cmd, dbCommon* pRecord, IOSCANPVT* iopvt) 
 	return 0;
 }
 
-static long EL30XX_read_record(aiRecord* prec) {
+static long EL30XX_read_record(void* prec) {
 	struct aiRecord* pRecord = (struct aiRecord*)prec;
 	EL30XXStandardInputPDO_t* spdo;
 	uint16_t buf[2];
@@ -233,24 +228,26 @@ static long EL30XX_read_record(aiRecord* prec) {
 //	EL36XX Device support
 //
 //======================================================//
-static long EL36XX_read_record(aiRecord* precord);
+static long EL36XX_read_record(void* precord);
 
-aidset devEL36XX = {
-	{
-		6,
-		EL3XXX_dev_report,
-		EL3XXX_init,
-		EL3XXX_init_record,
-		EL3XXX_get_ioint_info,
-	},
-	EL36XX_read_record,
-	EL3XXX_linconv,
+struct devEL36XX_t {
+	long number;
+	DEVSUPFUN dev_report;
+	DEVSUPFUN init;
+	DEVSUPFUN init_record;
+	DEVSUPFUN get_ioint_info;
+	DEVSUPFUN read_record;
+	DEVSUPFUN linconv;
+} devEL36XX = {
+	6,
+	(DEVSUPFUN)EL3XXX_dev_report,
+	(DEVSUPFUN)EL3XXX_init,
+	(DEVSUPFUN)EL3XXX_init_record,
+	(DEVSUPFUN)EL3XXX_get_ioint_info,
+	(DEVSUPFUN)EL36XX_read_record,
+	(DEVSUPFUN)EL3XXX_linconv,
 };
-
-extern "C"
-{
-	epicsExportAddress(dset, devEL36XX);
-}
+epicsExportAddress(dset, devEL36XX);
 
 #pragma pack(1)
 struct EL36XXInputPDO_t {
@@ -272,7 +269,7 @@ struct EL36XXInputPDO_t {
 DEFINE_SINGLE_CHANNEL_INPUT_PDO(EL36XXInputPDO_t, EL3681);
 DEFINE_DUMMY_OUTPUT_PDO_CHECK(EL3681); // Currently no output support for EL3681 outputs. This is a TODO!
 
-static long EL36XX_read_record(aiRecord* prec) {
+static long EL36XX_read_record(void* prec) {
 	struct aiRecord* pRecord = (struct aiRecord*)prec;
 	uint16_t buf[STRUCT_SIZE_TO_MODBUS_SIZE(sizeof(EL36XXInputPDO_t))];
 	EL36XXInputPDO_t* pdo = NULL;
@@ -312,24 +309,26 @@ static long EL36XX_read_record(aiRecord* prec) {
 //	EL331X Device support
 //
 //======================================================//
-static long EL331X_read_record(aiRecord* precord);
+static long EL331X_read_record(void* precord);
 
-aidset devEL331X = {
-	{
-		6,
-		EL3XXX_dev_report,
-		EL3XXX_init,
-		EL3XXX_init_record,
-		EL3XXX_get_ioint_info,
-	},
-	EL331X_read_record,
-	EL3XXX_linconv,
+struct devEL331X_t {
+	long number;
+	DEVSUPFUN dev_report;
+	DEVSUPFUN init;
+	DEVSUPFUN init_record;
+	DEVSUPFUN get_ioint_info;
+	DEVSUPFUN read_record;
+	DEVSUPFUN linconv;
+} devEL331X = {
+	6,
+	(DEVSUPFUN)EL3XXX_dev_report,
+	(DEVSUPFUN)EL3XXX_init,
+	(DEVSUPFUN)EL3XXX_init_record,
+	(DEVSUPFUN)EL3XXX_get_ioint_info,
+	(DEVSUPFUN)EL331X_read_record,
+	(DEVSUPFUN)EL3XXX_linconv,
 };
-
-extern "C"
-{
-	epicsExportAddress(dset, devEL331X);
-}
+epicsExportAddress(dset, devEL331X);
 
 #pragma pack(1)
 struct EL331XInputPDO_t {
@@ -360,7 +359,7 @@ DEFINE_SINGLE_CHANNEL_INPUT_PDO(EL331XInputPDO_t, EL3314);
 DEFINE_SINGLE_CHANNEL_INPUT_PDO(EL331XInputPDO_t, EL3312);
 DEFINE_SINGLE_CHANNEL_INPUT_PDO(EL331XInputPDO_t, EL3311);
 
-static long EL331X_read_record(aiRecord* prec) {
+static long EL331X_read_record(void* prec) {
 	struct aiRecord* pRecord = (struct aiRecord*)prec;
 
 	uint16_t buf[2];

--- a/ek9000App/src/devEL4XXX.cpp
+++ b/ek9000App/src/devEL4XXX.cpp
@@ -35,26 +35,24 @@
 
 static long EL40XX_dev_report(int after);
 static long EL40XX_init(int after);
-static long EL40XX_init_record(dbCommon* record);
-static long EL40XX_write_record(aoRecord* record);
-static long EL40XX_linconv(aoRecord* precord, int after);
+static long EL40XX_init_record(void* record);
+static long EL40XX_write_record(void* record);
+static long EL40XX_linconv(void* precord, int after);
 
-aodset devEL40XX = {
-	{
-		6,
-		EL40XX_dev_report,
-		EL40XX_init,
-		EL40XX_init_record,
-		NULL,
-	},
-	EL40XX_write_record,
-	EL40XX_linconv,
+struct devEL40XX_t {
+	long num;
+	DEVSUPFUN report;
+	DEVSUPFUN init;
+	DEVSUPFUN init_record;
+	DEVSUPFUN ioint_info;
+	DEVSUPFUN write_record;
+	DEVSUPFUN linconv;
+} devEL40XX = {
+	6,	  (DEVSUPFUN)EL40XX_dev_report,	  (DEVSUPFUN)EL40XX_init,	 (DEVSUPFUN)EL40XX_init_record,
+	NULL, (DEVSUPFUN)EL40XX_write_record, (DEVSUPFUN)EL40XX_linconv,
 };
 
-extern "C"
-{
-	epicsExportAddress(dset, devEL40XX);
-}
+epicsExportAddress(dset, devEL40XX);
 
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4001);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4002);
@@ -134,7 +132,7 @@ static long EL40XX_init(int) {
 	return 0;
 }
 
-static long EL40XX_init_record(dbCommon* record) {
+static long EL40XX_init_record(void* record) {
 	aoRecord* pRecord = (aoRecord*)record;
 	pRecord->dpvt = util::allocDpvt();
 	TerminalDpvt_t* dpvt = (TerminalDpvt_t*)pRecord->dpvt;
@@ -169,7 +167,7 @@ static long EL40XX_init_record(dbCommon* record) {
 	return 0;
 }
 
-static long EL40XX_write_record(aoRecord* record) {
+static long EL40XX_write_record(void* record) {
 	struct aoRecord* prec = (struct aoRecord*)record;
 	if (prec->pact)
 		prec->pact = FALSE;
@@ -180,6 +178,6 @@ static long EL40XX_write_record(aoRecord* record) {
 	return 0;
 }
 
-static long EL40XX_linconv(aoRecord*, int) {
+static long EL40XX_linconv(void*, int) {
 	return 0;
 }

--- a/ek9000App/src/devEL50XX.cpp
+++ b/ek9000App/src/devEL50XX.cpp
@@ -71,8 +71,8 @@ static long el50xx_init(int) {
 	return 0;
 }
 
-static long el50xx_init_record(dbCommon* precord) {
-	longinRecord* record = reinterpret_cast<longinRecord*>(precord);
+static long el50xx_init_record(void* precord) {
+	longinRecord* record = static_cast<longinRecord*>(precord);
 	record->dpvt = util::allocDpvt();
 	TerminalDpvt_t* dpvt = static_cast<TerminalDpvt_t*>(record->dpvt);
 	uint16_t termid = 0;
@@ -110,8 +110,9 @@ static long el50xx_init_record(dbCommon* precord) {
 	return 0;
 }
 
-static long el50xx_get_ioint_info(int cmd, dbCommon* pRecord, IOSCANPVT* iopvt) {
+static long el50xx_get_ioint_info(int cmd, void* prec, IOSCANPVT* iopvt) {
 	UNUSED(cmd);
+	struct dbCommon* pRecord = static_cast<struct dbCommon*>(prec);
 	TerminalDpvt_t* dpvt = static_cast<TerminalDpvt_t*>(pRecord->dpvt);
 	if (!util::DpvtValid(dpvt))
 		return 1;
@@ -120,16 +121,21 @@ static long el50xx_get_ioint_info(int cmd, dbCommon* pRecord, IOSCANPVT* iopvt) 
 	return 0;
 }
 
-static long el50xx_read_record(longinRecord* precord);
+static long el50xx_read_record(void* precord);
 
-longindset devEL50XX = {
-	{
-		5,
-		el50xx_dev_report,
-		el50xx_init,
-		el50xx_init_record,
-		el50xx_get_ioint_info,
-	},
+struct devEL50XX_t {
+	long number;
+	DEVSUPFUN dev_report;
+	DEVSUPFUN init;
+	DEVSUPFUN init_record;
+	DEVSUPFUN get_ioint_info;
+	DEVSUPFUN read_record;
+} devEL50XX = {
+	5,
+	(DEVSUPFUN)el50xx_dev_report,
+	(DEVSUPFUN)el50xx_init,
+	el50xx_init_record,
+	(DEVSUPFUN)el50xx_get_ioint_info,
 	el50xx_read_record,
 };
 
@@ -138,7 +144,8 @@ extern "C"
 	epicsExportAddress(dset, devEL50XX);
 }
 
-static long el50xx_read_record(longinRecord* precord) {
+static long el50xx_read_record(void* prec) {
+	longinRecord* precord = static_cast<longinRecord*>(prec);
 	TerminalDpvt_t* dpvt = static_cast<TerminalDpvt_t*>(precord->dpvt);
 
 	if (!util::DpvtValid(dpvt))
@@ -190,16 +197,21 @@ static long el50xx_read_record(longinRecord* precord) {
 	return 0;
 }
 
-static long el5042_read_record(longinRecord* prec);
+static long el5042_read_record(void* prec);
 
-longindset devEL5042 = {
-	{
-		5,
-		el50xx_dev_report,
-		el50xx_init,
-		el50xx_init_record,
-		el50xx_get_ioint_info,
-	},
+struct devEL5042_t {
+	long number;
+	DEVSUPFUN dev_report;
+	DEVSUPFUN init;
+	DEVSUPFUN init_record;
+	DEVSUPFUN get_ioint_info;
+	DEVSUPFUN read_record;
+} devEL5042 = {
+	5,
+	(DEVSUPFUN)el50xx_dev_report,
+	(DEVSUPFUN)el50xx_init,
+	el50xx_init_record,
+	(DEVSUPFUN)el50xx_get_ioint_info,
 	el5042_read_record,
 };
 
@@ -229,7 +241,8 @@ DEFINE_SINGLE_CHANNEL_INPUT_PDO(EL5042InputPDO_t, EL5042);
 Called to read the specified record
 -------------------------------------
 */
-static long el5042_read_record(longinRecord* precord) {
+static long el5042_read_record(void* prec) {
+	longinRecord* precord = static_cast<longinRecord*>(prec);
 	TerminalDpvt_t* dpvt;
 	EL5042InputPDO_t* pdo;
 


### PR DESCRIPTION
EPICS base versions prior to 7.0.4 fail to compile with this enabled in C++ mode.
