### PR TITLE
Fix signedness handling for EL3XXX and EL4XXX terminals

### DIFF
--- a/ek9000App/src/devEL3XXX.cpp
+++ b/ek9000App/src/devEL3XXX.cpp
@@ -131,7 +131,7 @@ struct EL30XXStandardInputPDO_t {
 	uint8_t _r2 : 6; // Last bit in this align is Sync error for EL31XX
 	uint8_t txpdo_state : 1;
 	uint8_t txpdo_toggle : 1;
-	uint16_t value;
+	int16_t value;	// Must be signed to accommodate bipolar terminals. Unsigned representation still defines range as 0-32767, so this is safe.
 };
 #pragma pack()
 
@@ -339,7 +339,7 @@ struct EL331XInputPDO_t {
 	uint8_t error : 1;
 	uint8_t txpdo_state : 1;
 	uint8_t txpdo_toggle : 1;
-	uint16_t value;
+	int16_t value;
 };
 
 struct EL3314_0010_InputPDO_t {
@@ -351,7 +351,7 @@ struct EL3314_0010_InputPDO_t {
 	uint8_t txpdo_state : 1;
 	uint8_t txpdo_toggle : 1;
 	uint8_t padding1 : 7; // Pad it out to byte boundary
-	uint16_t value;
+	int16_t value;
 };
 #pragma pack()
 

--- a/ek9000App/src/devEL3XXX.cpp
+++ b/ek9000App/src/devEL3XXX.cpp
@@ -131,7 +131,8 @@ struct EL30XXStandardInputPDO_t {
 	uint8_t _r2 : 6; // Last bit in this align is Sync error for EL31XX
 	uint8_t txpdo_state : 1;
 	uint8_t txpdo_toggle : 1;
-	int16_t value;	// Must be signed to accommodate bipolar terminals. Unsigned representation still defines range as 0-32767, so this is safe.
+	int16_t value; // Must be signed to accommodate bipolar terminals. Unsigned representation still defines range as
+				   // 0-32767, so this is safe.
 };
 #pragma pack()
 

--- a/ek9000App/src/devEL4XXX.cpp
+++ b/ek9000App/src/devEL4XXX.cpp
@@ -58,10 +58,10 @@ struct devEL40XX_t {
 
 epicsExportAddress(dset, devEL40XX);
 
-// The default representation for all of these terminals is signed. Unsigned may also be set, even for the bipolar terminals that
-// may produce a negative value. To retain some level of support for unsigned representation, terminals that have a positive
-// output range use uint16_t as the PDO type. Bipolar terminals always use int16_t to support negative values and will behave incorrectly
-// if you choose the unsigned (or absolute w/MSB sign) representation. 
+// The default representation for all of these terminals is signed. Unsigned may also be set, even for the bipolar
+// terminals that may produce a negative value. To retain some level of support for unsigned representation, terminals
+// that have a positive output range use uint16_t as the PDO type. Bipolar terminals always use int16_t to support
+// negative values and will behave incorrectly if you choose the unsigned (or absolute w/MSB sign) representation.
 
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4001);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4002);
@@ -75,16 +75,16 @@ DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4021);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4022);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4024);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4028);
-DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4031);		// EL403X support negative output values.
+DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4031); // EL403X support negative output values.
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4032);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4034);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4038);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4102);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4104);
-DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4112);		// EL411X support negative output values.
+DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4112); // EL411X support negative output values.
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4114);
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(uint16_t, EL4122);
-DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4132);		// EL413X support negative output values.
+DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4132); // EL413X support negative output values.
 DEFINE_SINGLE_CHANNEL_OUTPUT_PDO(int16_t, EL4134);
 
 static bool isTerminalSigned(int id) {


### PR DESCRIPTION

For analog input terminals, both signed and unsigned representations behave like a signed 16-bit integer. In the case of unsigned, the value is limited to the range 0-32767, the former is limited to -32768-32767. As such, treating the values from the device as int16 (and thus sign extending it when assigning to RVAL) is the correct way of doing things.

MSB representation is still not handled in this PR.

For analog output terminals, signed behaves as described above, but unsigned has the full range you would expect: 0-65k. To improve support for this, I've chosen a middle ground-- bipolar terminals will assume the PDO is signed and unipolar terminals will assume it is unsigned. Since unipolar terminals with the signed PDO can only have values 0-32k, it is safe to treat them as `uint16`.

The one drawback here is the unsigned PDO type will not behave correctly if it's set on a bipolar terminal. I suspect this is a rare use-case anyways, though.

More context on #45 