### PR TITLE
Misc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ BhcConfigFiles/
 .cache
 
 st*.cmd
+
+RELEASE_SITE

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Because it uses modbus, it's runnable on any IOC without needing a kernel module
 
 [Documentation](https://github.com/slaclab/epics-ek9000/wiki/Manual)
 [DOE Code](https://www.osti.gov/doecode/biblio/75566)
+[doi:10.11578/dc.20220707.2](https://doi.org/10.11578/dc.20220707.2)
 
 ## Dependencies
 
@@ -13,7 +14,7 @@ Because it uses modbus, it's runnable on any IOC without needing a kernel module
 
 ## Building
 
-C++11 is **required** as of R1.7.3
+C++11 is **required** as of R1.7.4
 
 Build like any other EPICS module:
 ```
@@ -58,3 +59,12 @@ At least some of the following terminal families are supported:
 
 Any other terminals are not generally supported, but a few exceptions exist.
 Support for motor terminals (EL70XX) is currently being developed.
+
+## Copyright Notice:
+
+COPYRIGHT © SLAC National Accelerator Laboratory. All rights reserved. This work is supported [in part] by the U.S. Department of Energy, Office of Basic Energy Sciences under contract DE-AC02-76SF00515.
+
+## Usage Restrictions:
+
+Neither the name of the Leland Stanford Junior University, SLAC National Accelerator Laboratory, U.S. Department of Energy nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Because it uses modbus, it's runnable on any IOC without needing a kernel module
 
 ## Building
 
-See the wiki page for instructions on building and a small example.
+C++11 is **required** as of R1.7.3
+
+Build like any other EPICS module:
+```
+make
+```
 
 ## Contributing
 
@@ -23,7 +28,7 @@ If you'd like to contribute to this, you can open a pull request with changes, a
 
 If you have any questions or comments about the module, you can reach me at jeremy.lorelli.1337@gmail.com
 
-# Known Issues
+## Known Issues
 
 The EK9000 doesn't really make figuring out a register map easy, so please keep these things in mind:
 

--- a/ek9000App/Db/EL3311.template
+++ b/ek9000App/Db/EL3311.template
@@ -5,6 +5,7 @@ record(ai,"$(TERMINAL):1")
 	field(SCAN, "I/O Intr")
 	field(PREC, "$(PREC=3)")
 	field(ESLO, "0.1")
+	field(LINR, "$(LINR=SLOPE)")
 	field(INP, "@device=$(DEVICE),pos=$(POS),channel=1,type=EL3311")
 }
 

--- a/ek9000App/Db/EL3312.template
+++ b/ek9000App/Db/EL3312.template
@@ -5,6 +5,7 @@ record(ai,"$(TERMINAL):1")
 	field(SCAN, "I/O Intr")
 	field(PREC, "$(PREC=3)")
 	field(ESLO, "0.1")
+	field(LINR, "$(LINR=SLOPE)")
 	field(INP, "@device=$(DEVICE),pos=$(POS),channel=1,type=EL3312")
 }
 
@@ -15,6 +16,7 @@ record(ai,"$(TERMINAL):2")
 	field(SCAN, "I/O Intr")
 	field(PREC, "$(PREC=3)")
 	field(ESLO, "0.1")
+	field(LINR, "$(LINR=SLOPE)")
 	field(INP, "@device=$(DEVICE),pos=$(POS),channel=2,type=EL3312")
 }
 

--- a/ek9000App/Db/EL3314.template
+++ b/ek9000App/Db/EL3314.template
@@ -5,6 +5,7 @@ record(ai,"$(TERMINAL):1")
 	field(SCAN, "I/O Intr")
 	field(PREC, "$(PREC=3)")
 	field(ESLO, "0.1")
+	field(LINR, "$(LINR=SLOPE)")
 	field(INP, "@device=$(DEVICE),pos=$(POS),channel=1,type=EL3314")
 }
 
@@ -15,6 +16,7 @@ record(ai,"$(TERMINAL):2")
 	field(SCAN, "I/O Intr")
 	field(PREC, "$(PREC=3)")
 	field(ESLO, "0.1")
+	field(LINR, "$(LINR=SLOPE)")
 	field(INP, "@device=$(DEVICE),pos=$(POS),channel=2,type=EL3314")
 }
 
@@ -25,6 +27,7 @@ record(ai,"$(TERMINAL):3")
 	field(SCAN, "I/O Intr")
 	field(PREC, "$(PREC=3)")
 	field(ESLO, "0.1")
+	field(LINR, "$(LINR=SLOPE)")
 	field(INP, "@device=$(DEVICE),pos=$(POS),channel=3,type=EL3314")
 }
 
@@ -35,6 +38,7 @@ record(ai,"$(TERMINAL):4")
 	field(SCAN, "I/O Intr")
 	field(PREC, "$(PREC=3)")
 	field(ESLO, "0.1")
+	field(LINR, "$(LINR=SLOPE)")
 	field(INP, "@device=$(DEVICE),pos=$(POS),channel=4,type=EL3314")
 }
 

--- a/ek9000App/src/Makefile
+++ b/ek9000App/src/Makefile
@@ -20,6 +20,8 @@ USR_CXXFLAGS += -fsanitize=address
 USR_LDFLAGS += -fsanitize=address -static-libasan
 endif
 
+USR_CXXFLAGS += -std=c++11
+
 # Unfortunately EPICS and some of the motor record headers cause warnings (well, and one of our generated headers)
 # So just disable those couple warnings to avoid spam (and so PEDANTIC=1 actually builds with -Werror
 USR_CXXFLAGS += -Wno-deprecated-declarations -Wno-unused-variable

--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -797,7 +797,7 @@ uint16_t devEK9000::ReadTerminalID(uint16_t index) {
 		// Check if there are no further terminals on the rail, otherwise continue reading
 		if (off > 0 && m_terminals[off] == 0)
 			break;
-		const size_t toRead = util::clamp(ArraySize(m_terminals) - off, 0, 125);
+		const size_t toRead = util::clamp(ArraySize(m_terminals) - off, 0UL, 125UL);
 		if (this->doModbusIO(0, MODBUS_READ_INPUT_REGISTERS, 0x6000, m_terminals + off, toRead) != asynSuccess) {
 			LOG_WARNING(this, "%s: Failed to read terminal layout\n", m_name.data());
 			break;

--- a/ek9000App/src/devEK9000.cpp
+++ b/ek9000App/src/devEK9000.cpp
@@ -1572,27 +1572,31 @@ struct StatusReg {
 	StatusFlags flags;
 };
 
-CONSTEXPR StatusReg status_regs[] = {{"analogOutputs", 0x1010, STATUS_RD | STATUS_STATIC},
-									 {"analogInputs", 0x1011, STATUS_RD | STATUS_STATIC},
-									 {"digitalOutputs", 0x1012, STATUS_RD | STATUS_STATIC},
-									 {"digitalInputs", 0x1013, STATUS_RD | STATUS_STATIC},
-									 {"fallbacks", 0x1021, STATUS_RD},
-									 {"tcpConnections", 0x1022, STATUS_RD},
-									 {"hardwareVer", 0x1030, STATUS_RD | STATUS_STATIC},
-									 {"softVerMain", 0x1031, STATUS_RD | STATUS_STATIC},
-									 {"softVerSub", 0x1032, STATUS_RD | STATUS_STATIC},
-									 {"softVerBeta", 0x1033, STATUS_RD | STATUS_STATIC},
-									 {"serialNum", 0x1034, STATUS_RD | STATUS_STATIC},
-									 {"prodDay", 0x1035, STATUS_RD | STATUS_STATIC},
-									 {"prodMonth", 0x1036, STATUS_RD | STATUS_STATIC},
-									 {"prodYear", 0x1037, STATUS_RD | STATUS_STATIC},
-									 {"ebusStatus", 0x1040, STATUS_RD},
-									 {"wdtTime", 0x1120, STATUS_RW},
-									 {"wdtReset", 0x1121, STATUS_RW},
-									 {"wdtType", 0x1122, STATUS_RW},
-									 {"wdtFallback", 0x1123, STATUS_RW},
-									 {"writelock", 0x1124, STATUS_RW},
-									 {"ebusMode", 0x1140, STATUS_RW}};
+// clang-format off
+CONSTEXPR StatusReg status_regs[] = {
+	{"analogOutputs",   0x1010, STATUS_RD | STATUS_STATIC},
+	{"analogInputs",    0x1011, STATUS_RD | STATUS_STATIC},
+	{"digitalOutputs",  0x1012, STATUS_RD | STATUS_STATIC},
+	{"digitalInputs",   0x1013, STATUS_RD | STATUS_STATIC},
+	{"fallbacks",       0x1021, STATUS_RD                },
+	{"tcpConnections",  0x1022, STATUS_RD                },
+	{"hardwareVer",     0x1030, STATUS_RD | STATUS_STATIC},
+	{"softVerMain",     0x1031, STATUS_RD | STATUS_STATIC},
+	{"softVerSub",      0x1032, STATUS_RD | STATUS_STATIC},
+	{"softVerBeta",     0x1033, STATUS_RD | STATUS_STATIC},
+	{"serialNum",       0x1034, STATUS_RD | STATUS_STATIC},
+	{"prodDay",         0x1035, STATUS_RD | STATUS_STATIC},
+	{"prodMonth",       0x1036, STATUS_RD | STATUS_STATIC},
+	{"prodYear",        0x1037, STATUS_RD | STATUS_STATIC},
+	{"ebusStatus",      0x1040, STATUS_RD                },
+	{"wdtTime",         0x1120, STATUS_RW                },
+	{"wdtReset",        0x1121, STATUS_RW                },
+	{"wdtType",         0x1122, STATUS_RW                },
+	{"wdtFallback",     0x1123, STATUS_RW                },
+	{"writelock",       0x1124, STATUS_RW                },
+	{"ebusMode",        0x1140, STATUS_RW                }
+};
+// clang-format on
 
 // Read-only status info (tcp connections, fallbacks triggered, etc.)
 struct devEK9000ConfigRO_t {

--- a/ek9000App/src/scripts/Makefile
+++ b/ek9000App/src/scripts/Makefile
@@ -4,6 +4,6 @@ clean:
 	rm -f ../terminals.h
 
 ../terminals.h: terminals.json
-	python3 generate.py -o "$(PWD)/../terminals.h" terminals.json 
+	python3 generate.py -o "$(PWD)/../terminals.h" terminals.json
 
-.PHONY: download clean
+.PHONY: clean

--- a/ek9000App/src/scripts/terminals.json
+++ b/ek9000App/src/scripts/terminals.json
@@ -998,7 +998,8 @@
 			"dtyp": "EL331X",
 			"defaults": {
 				"ESLO": "0.1",
-				"EGU": "C"
+				"EGU": "C",
+				"LINR": "$(LINR=SLOPE)"
 			}
 		},
 		{
@@ -1011,7 +1012,8 @@
 			"dtyp": "EL331X",
 			"defaults": {
 				"ESLO": "0.1",
-				"EGU": "C"
+				"EGU": "C",
+				"LINR": "$(LINR=SLOPE)"
 			}
 		},
 		{
@@ -1024,7 +1026,8 @@
 			"dtyp": "EL331X",
 			"defaults": {
 				"ESLO": "0.1",
-				"EGU": "C"
+				"EGU": "C",
+				"LINR": "$(LINR=SLOPE)"
 			}
 		},
 		{


### PR DESCRIPTION
* Use C++11 always
* Set LINR=SLOPE for thermocouple terminals (#61)
* Fix signed compare warnings
* Cleanup formatting

@marciodo review is optional here because there is no charge code for this work.

Closes #61